### PR TITLE
add missing types

### DIFF
--- a/darwin/app_kit.nim
+++ b/darwin/app_kit.nim
@@ -1,5 +1,5 @@
 import foundation
-import app_kit / [ nsscreen, nsview, nsevent, nscursor, nspasteboard, nswindow ]
-export foundation, nsscreen, nsview, nsevent, nscursor, nspasteboard, nswindow
+import app_kit / [ nsscreen, nsview, nsevent, nscursor, nspasteboard, nswindow, nsapplication, nsmenu, nsresponder, nstext, nstextview, nswindowcontroller ]
+export foundation, nsscreen, nsview, nsevent, nscursor, nspasteboard, nswindow, nsapplication, nsmenu, nsresponder, nstext, nstextview, nswindowcontroller
 
 {.passL:"-framework AppKit".}

--- a/darwin/app_kit/nsapplication.nim
+++ b/darwin/app_kit/nsapplication.nim
@@ -1,0 +1,2 @@
+import ./nsresponder
+type NSApplication* = ptr object of NSResponder

--- a/darwin/app_kit/nsmenu.nim
+++ b/darwin/app_kit/nsmenu.nim
@@ -1,0 +1,5 @@
+import ../objc/runtime
+
+type
+    NSMenu* = ptr object of NSObject
+    NSMenuItem* = ptr object of NSObject

--- a/darwin/app_kit/nsresponder.nim
+++ b/darwin/app_kit/nsresponder.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+    NSResponder* = ptr object of NSObject

--- a/darwin/app_kit/nstext.nim
+++ b/darwin/app_kit/nstext.nim
@@ -1,0 +1,2 @@
+import ./nsview
+type NSText* = ptr object of NSView

--- a/darwin/app_kit/nstextview.nim
+++ b/darwin/app_kit/nstextview.nim
@@ -1,0 +1,2 @@
+import ./nstext
+type NSTextView* = ptr object of NSText

--- a/darwin/app_kit/nswindowcontroller.nim
+++ b/darwin/app_kit/nswindowcontroller.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+    NSWindowController* = ptr object of NSObject

--- a/darwin/foundation.nim
+++ b/darwin/foundation.nim
@@ -1,5 +1,5 @@
-import foundation / [ nsstring, nsgeometry, nsarray, nsdata, nsset, nsenumerator, nserror, nsdate, nsdictionary, nsnumber, nsdecimal_number, nslocale, nspath_utilities ]
-export nsstring, nsgeometry, nsarray, nsdata, nsset, nsenumerator, nserror, nsdate, nsdictionary, nsnumber, nsdecimal_number, nslocale, nspath_utilities
+import foundation / [ nsstring, nsgeometry, nsarray, nsdata, nsset, nsenumerator, nserror, nsdate, nsdictionary, nsnumber, nsdecimal_number, nslocale, nspath_utilities, nsprocessinfo, nsurl, nsurlrequest ]
+export nsstring, nsgeometry, nsarray, nsdata, nsset, nsenumerator, nserror, nsdate, nsdictionary, nsnumber, nsdecimal_number, nslocale, nspath_utilities, nsprocessinfo, nsurl, nsurlrequest
 
 import objc/runtime
 export NSObject, NSLog, isKindOfClass, retain, release, alloc, init

--- a/darwin/foundation/nsprocessinfo.nim
+++ b/darwin/foundation/nsprocessinfo.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+    NSProcessInfo* = ptr object of NSObject

--- a/darwin/foundation/nsurl.nim
+++ b/darwin/foundation/nsurl.nim
@@ -1,0 +1,3 @@
+import ../objc/runtime
+
+type NSURL* = ptr object of NSObject

--- a/darwin/foundation/nsurlrequest.nim
+++ b/darwin/foundation/nsurlrequest.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+    NSURLRequest* = ptr object of NSObject


### PR DESCRIPTION
btw I've implemented macro which do something like this , dont know if it's acceptable to add to runtime file.
``` nim
objcr:
    var appDel = [AppDelegate alloc]
    [appDel init]
    [NSApplication sharedApplication]
    [NSApp setDelegate: appDel]
    setIvar(appDel, ivar, cast[ID](webview))
    createMenu()
    [NSApp finishLaunching]
    [NSApp activateIgnoringOtherApps: true]
```
even nested msg send and multiple named args `[editMenuItem initWithTitle: "Edit", action: "", keyEquivalent: ""]`