### PR TITLE
add webkit related types and other procs

### DIFF
--- a/darwin/app_kit/nsmenu.nim
+++ b/darwin/app_kit/nsmenu.nim
@@ -3,3 +3,11 @@ import ../objc/runtime
 type
     NSMenu* = ptr object of NSObject
     NSMenuItem* = ptr object of NSObject
+
+proc initWithTitle*(self: NSMenu, str: NSString): NSMenu {.objc: "initWithTitle:", discardable.}
+
+proc initWithTitle*(self: NSMenuItem, str: NSString, action: SEL, key: NSString): NSMenuItem {.objc: "initWithTitle:action:keyEquivalent:", discardable.}
+
+proc setSubmenu*(self: NSMenuItem, menu: NSMenu)  {.objc: "setSubmenu:".}
+
+proc addItem*(self: NSMenu, item: NSMenuItem)  {.objc: "addItem:".}

--- a/darwin/app_kit/nswindow.nim
+++ b/darwin/app_kit/nswindow.nim
@@ -31,6 +31,12 @@ proc scaleFactor*(s: NSWindow): CGFloat =
     else:
         result = 1
 
+proc initWithContentRect*(s: NSWindow, contentRect: NSRect, styleMask: NSWindowStyleMask, backing: NSBackingStoreType, `defer`: BOOL):  NSWindow {.objc: "initWithContentRect:styleMask:backing:defer:", discardable.}
+proc setTitle*(s: NSWindow, title: NSString) {.objc: "setTitle:".}
+proc setContentView*(s: NSWindow, view: NSView) {.objc: "setContentView:".}
+proc center*(s: NSWindow) {.objc.}
 proc frame*(s: NSWindow): NSRect {.objc.}
+proc setFrame*(s: NSWindow, rect: NSRect, display: BOOL) {.objc: "setFrame:display:".}
 proc contentRectForFrameRect*(s: NSWindow, r: NSRect): NSRect {.objc: "contentRectForFrameRect:".}
 proc contentView*(s: NSWindow): NSView {.objc.}
+proc orderFrontRegardless*(s: NSWindow) {.objc.}

--- a/darwin/foundation/nsstring.nim
+++ b/darwin/foundation/nsstring.nim
@@ -36,6 +36,7 @@ template `==`*(s1, s2: NSString): bool = s1.isEqualToString(s2)
 
 proc withUTF8String*(n: typedesc[NSString], s: cstring): NSString {.objc: "stringWithUTF8String:".}
 proc stringWithNSString*(n: NSString): string = $n.UTF8String
+proc stringByAppendingString*(s: NSString, a: NSString): NSString {.objc: "stringByAppendingString:".}
 
 converter toNSString*(s: string): NSString = NSString.withUTF8String(s)
 converter nsstringtostring*(s: NSString): string = stringWithNSString(s)

--- a/darwin/foundation/nsurl.nim
+++ b/darwin/foundation/nsurl.nim
@@ -1,3 +1,5 @@
 import ../objc/runtime
 
 type NSURL* = ptr object of NSObject
+
+proc URLWithString*(self: typedesc[NSURL], str: NSString): NSURL {.objc: "URLWithString:".}

--- a/darwin/foundation/nsurlrequest.nim
+++ b/darwin/foundation/nsurlrequest.nim
@@ -1,4 +1,7 @@
 import ../objc/runtime
+import ./nsurl
 
 type
     NSURLRequest* = ptr object of NSObject
+
+proc requestWithURL*(self: typedesc[NSURLRequest], url: NSURL): NSURLRequest {.objc: "requestWithURL:".}

--- a/darwin/web_kit.nim
+++ b/darwin/web_kit.nim
@@ -1,2 +1,4 @@
-import web_kit / [ wkwebview ]
-export wkwebview
+import web_kit / [wkwebview, wkwebviewconfiguration, wknavigation,
+    wkusercontentcontroller, wkuserscript, wkpreferences]
+export wkwebview, wkwebviewconfiguration, wknavigation, wkusercontentcontroller,
+    wkuserscript, wkpreferences

--- a/darwin/web_kit/wknavigation.nim
+++ b/darwin/web_kit/wknavigation.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+  WKNavigation* = ptr object of NSObject

--- a/darwin/web_kit/wkpreferences.nim
+++ b/darwin/web_kit/wkpreferences.nim
@@ -1,0 +1,9 @@
+import ../objc/runtime
+
+type
+  WKPreferences* = ptr object of NSObject
+
+proc setDeveloperExtrasEnabled*(self: WKPreferences, a: BOOL) {.objc: "_setDeveloperExtrasEnabled:".}
+proc setFullScreenEnabled*(self: WKPreferences, a: BOOL) {.objc: "_setFullScreenEnabled:".}
+proc setJavaScriptCanAccessClipboard*(self: WKPreferences, a: BOOL) {.objc: "_setJavaScriptCanAccessClipboard:".}
+proc setDOMPasteAllowed*(self: WKPreferences, a: BOOL) {.objc: "_setDOMPasteAllowed:".}

--- a/darwin/web_kit/wkusercontentcontroller.nim
+++ b/darwin/web_kit/wkusercontentcontroller.nim
@@ -1,0 +1,7 @@
+import ../objc/runtime
+import ./wkuserscript
+
+type
+  WKUserContentController* = ptr object of NSObject
+
+proc addUserScript*(self: WKUserContentController, userScript: WKUserScript): void {.objc: "addUserScript:".}

--- a/darwin/web_kit/wkuserscript.nim
+++ b/darwin/web_kit/wkuserscript.nim
@@ -1,0 +1,9 @@
+import ../objc/runtime
+
+type
+  WKUserScript* = ptr object of NSObject
+  WKUserScriptInjectionTime* {.size: sizeof(uint32).} = enum
+    AtDocumentStart = 0
+    AtDocumentEnd = 1
+
+proc initWithSource*(self: WKUserScript, source: NSString, injectionTime: WKUserScriptInjectionTime, forMainFrameOnly: BOOL): WKUserScript {.objc: "initWithSource:injectionTime:forMainFrameOnly:", discardable.}

--- a/darwin/web_kit/wkwebview.nim
+++ b/darwin/web_kit/wkwebview.nim
@@ -1,4 +1,8 @@
 import ../objc/runtime
+import ../core_graphics/cggeometry
+import ./wkwebviewconfiguration
+import ../foundation/[nsurl, nsurlrequest]
+import ./wknavigation
 
 when defined(ios):
   import ../ui_kit/uiview
@@ -7,3 +11,12 @@ else:
   import ../app_kit/nsview
   type WKWebView* = ptr object of NSView
 
+proc initWithFrame*(self: WKWebView, frame: CGRect): WKWebView {.objc: "initWithFrame:".}
+
+proc initWithFrameAndConfiguration*(self: WKWebView, frame: CGRect, conf: WKWebViewConfiguration): WKWebView {.objc: "initWithFrame:configuration:".}
+
+proc loadHTMLString*(self: WKWebView, str: NSString, baseURL: NSURL): WKNavigation {.objc: "loadHTMLString:baseURL:" , discardable.}
+
+proc loadRequest*(self: WKWebView, request: NSURLRequest): WKNavigation {.objc: "loadRequest:", discardable.}
+
+proc configuration*(self: WKWebView): WKWebViewConfiguration {.objc: "configuration".}

--- a/darwin/web_kit/wkwebviewconfiguration.nim
+++ b/darwin/web_kit/wkwebviewconfiguration.nim
@@ -1,0 +1,11 @@
+import ../objc/runtime
+import ./wkusercontentcontroller
+import ./wkpreferences
+type
+  WKWebViewConfiguration* = ptr object of NSObject
+
+proc newWKWebViewConfiguration*(a: typedesc[WKWebViewConfiguration]): WKWebViewConfiguration{.objc: "new".}
+
+proc userContentController*(self: WKWebViewConfiguration): WKUserContentController {.objc: "userContentController".}
+proc setUserContentController*(self: WKWebViewConfiguration, controller: WKUserContentController): void {.objc: "setUserContentController:".}
+proc preferences*(self: WKWebViewConfiguration): WKPreferences {.objc.}


### PR DESCRIPTION
I also wanna wraps `setDelegate:` related procs but like `NSWindow` 's 
https://developer.apple.com/documentation/appkit/nswindow/1419060-delegate?language=objc

but I dont know how to , as [NSWindowDelegate](https://developer.apple.com/documentation/appkit/nswindowdelegate?language=objc) is a protocol

sorry, I dont know how to contact you so ask here.