### PR TITLE
Add missing AppKit bindings

### DIFF
--- a/darwin/app_kit/nsbutton.nim
+++ b/darwin/app_kit/nsbutton.nim
@@ -1,7 +1,8 @@
 import ../objc/[runtime]
 import ../foundation/[nsstring]
 import ./nscontrol
-import ../app_kit/[nsimage, nsview]
+import ./nscell
+import ../app_kit/[nsimage]
 
 type
   NSButton* = ptr object of NSControl
@@ -26,6 +27,17 @@ type
     NSControlStateValueOff = 0,
     NSControlStateValueOn = 1
 
+# Enum for NSCellImagePosition
+type
+  NSCellImagePosition* {.size: sizeof(uint).} = enum
+    NSNoImage = 0,
+    NSImageOnly = 1,
+    NSImageLeft = 2,
+    NSImageRight = 3,
+    NSImageBelow = 4,
+    NSImageAbove = 5,
+    NSImageOverlaps = 6
+
 # Button title and image
 proc title*(self: NSButton): NSString {.objc: "title".}
 proc setTitle*(self: NSButton, title: NSString) {.objc: "setTitle:".}
@@ -35,6 +47,14 @@ proc image*(self: NSButton): NSImage {.objc: "image".}
 proc setImage*(self: NSButton, image: NSImage) {.objc: "setImage:".}
 proc alternateImage*(self: NSButton): NSImage {.objc: "alternateImage".}
 proc setAlternateImage*(self: NSButton, image: NSImage) {.objc: "setAlternateImage:".}
+
+# Image position and scaling
+proc imagePosition*(self: NSButton): NSCellImagePosition {.objc: "imagePosition".}
+proc setImagePosition*(self: NSButton, position: NSCellImagePosition) {.objc: "setImagePosition:".}
+proc imageScaling*(self: NSButton): NSImageScaling {.objc: "imageScaling".}
+proc setImageScaling*(self: NSButton, scaling: NSImageScaling) {.objc: "setImageScaling:".}
+proc imageHugsTitle*(self: NSButton): BOOL {.objc: "imageHugsTitle".}
+proc setImageHugsTitle*(self: NSButton, hugs: BOOL) {.objc: "setImageHugsTitle:".}
 
 # Button state and type
 proc state*(self: NSButton): NSControlStateValue {.objc: "state".}

--- a/darwin/app_kit/nsmenu.nim
+++ b/darwin/app_kit/nsmenu.nim
@@ -17,6 +17,11 @@ proc addItem*(self: NSMenu, title: NSString, action: SEL, key: NSString): NSMenu
 proc numberOfItems*(self: NSMenu): NSInteger {.objc.}
 proc itemAtIndex*(self: NSMenu, idx: NSInteger): NSMenuItem {.objc: "itemAtIndex:".}
 
+proc removeAllItems*(self: NSMenu) {.objc: "removeAllItems".}
+  ## Removes all items from the menu.
+  ## Available in macOS 10.6 and later.
+  ## This is more efficient than removing items one by one.
+  ## This does not post NSMenuDidRemoveItemNotification, for efficiency.
 
 proc setKeyEquivalentModifierMask*(self: NSMenuItem, mask: NSEventModifierFlags) {.objc: "setKeyEquivalentModifierMask:".}
 

--- a/darwin/app_kit/nstoolbar.nim
+++ b/darwin/app_kit/nstoolbar.nim
@@ -1,7 +1,9 @@
 import ../objc/runtime
 import ../foundation/nsstring
 import ../foundation/nsarray
+import ../foundation/nsgeometry
 import nsimage
+import nsview
 
 type
   NSToolbar* = ptr object of NSObject
@@ -92,3 +94,13 @@ proc isVisible*(self: NSToolbarItem): BOOL {.objc: "isVisible".}
 
 # Toolbar reference
 proc toolbar*(self: NSToolbarItem): NSToolbar {.objc: "toolbar".}
+
+# Custom view
+proc view*(self: NSToolbarItem): NSView {.objc: "view".}
+proc setView*(self: NSToolbarItem, view: NSView) {.objc: "setView:".}
+
+# Min/Max size (deprecated in macOS 10.0–12.0)
+proc minSize*(self: NSToolbarItem): NSSize {.objc: "minSize", deprecated: "Deprecated in macOS 10.0–12.0. Instead, let the system automatically measure the size of the view using constraints.".}
+proc setMinSize*(self: NSToolbarItem, size: NSSize) {.objc: "setMinSize:", deprecated: "Deprecated in macOS 10.0–12.0. Instead, let the system automatically measure the size of the view using constraints.".}
+proc maxSize*(self: NSToolbarItem): NSSize {.objc: "maxSize", deprecated: "Deprecated in macOS 10.0–12.0. Instead, let the system automatically measure the size of the view using constraints.".}
+proc setMaxSize*(self: NSToolbarItem, size: NSSize) {.objc: "setMaxSize:", deprecated: "Deprecated in macOS 10.0–12.0. Instead, let the system automatically measure the size of the view using constraints.".}


### PR DESCRIPTION
- NSButton: add imagePosition, imageScaling, imageHugsTitle properties
- NSButton: add NSCellImagePosition enum
- NSToolbarItem: add view property
- NSToolbarItem: add minSize/maxSize (deprecated) properties
- NSMenu: add removeAllItems method

All additions verified against Apple AppKit headers.