### PR TITLE
Add CFURL and CTFont bindings for font URL access

### DIFF
--- a/darwin/core_foundation/cfurl.nim
+++ b/darwin/core_foundation/cfurl.nim
@@ -2,6 +2,7 @@ import cfbase, cfstring
 
 type
     CFURL* = ptr object of CFObject
+    CFURLRef* = CFURL
     CFURLPathStyle* = enum
         kCFURLPOSIXPathStyle = 0
         kCFURLWindowsPathStyle = 2
@@ -12,3 +13,4 @@ proc CFURLGetTypeID*(): CFTypeID {.importc.}
 proc CFURLCreateWithBytes*(allocator: CFAllocator, URLBytes: pointer, length: CFIndex, encoding: CFStringEncoding, baseURL: CFURL): CFURL {.importc.}
 proc CFURLCreateWithString*(allocator: CFAllocator, URLString: CFString, baseURL: CFURL): CFURL {.importc.}
 proc CFURLCreateWithFileSystemPath*(allocator: CFAllocator, filePath: CFString, pathStyle: CFURLPathStyle, isDirectory: Boolean): CFURL {.importc.}
+proc getFileSystemRepresentation*(url: CFURLRef, resolveAgainstBase: Boolean, buffer: ptr uint8, maxBufLen: CFIndex): Boolean {.importc: "CFURLGetFileSystemRepresentation".}

--- a/darwin/core_foundation/cfurl.nim
+++ b/darwin/core_foundation/cfurl.nim
@@ -2,7 +2,6 @@ import cfbase, cfstring
 
 type
     CFURL* = ptr object of CFObject
-    CFURLRef* = CFURL
     CFURLPathStyle* = enum
         kCFURLPOSIXPathStyle = 0
         kCFURLWindowsPathStyle = 2
@@ -13,4 +12,4 @@ proc CFURLGetTypeID*(): CFTypeID {.importc.}
 proc CFURLCreateWithBytes*(allocator: CFAllocator, URLBytes: pointer, length: CFIndex, encoding: CFStringEncoding, baseURL: CFURL): CFURL {.importc.}
 proc CFURLCreateWithString*(allocator: CFAllocator, URLString: CFString, baseURL: CFURL): CFURL {.importc.}
 proc CFURLCreateWithFileSystemPath*(allocator: CFAllocator, filePath: CFString, pathStyle: CFURLPathStyle, isDirectory: Boolean): CFURL {.importc.}
-proc getFileSystemRepresentation*(url: CFURLRef, resolveAgainstBase: Boolean, buffer: ptr uint8, maxBufLen: CFIndex): Boolean {.importc: "CFURLGetFileSystemRepresentation".}
+proc getFileSystemRepresentation*(url: CFURL, resolveAgainstBase: Boolean, buffer: ptr uint8, maxBufLen: CFIndex): Boolean {.importc: "CFURLGetFileSystemRepresentation".}

--- a/darwin/core_text/ctfont.nim
+++ b/darwin/core_text/ctfont.nim
@@ -18,3 +18,7 @@ proc getBoundingRectsForGlyphs*(font: CTFont, orientation: CTFontOrientation, gl
 proc getAdvancesForGlyphs*(font: CTFont, orientation: CTFontOrientation, glyphs: ptr CGGlyph, advances: ptr CGSize, count: CFIndex): cdouble {.importc: "CTFontGetAdvancesForGlyphs".}
 
 proc copyGraphicsFont*(font: CTFont, attributes: CTFontDescriptor): CGFont {.importc: "CTFontCopyGraphicsFont".}
+
+var kCTFontURLAttribute* {.importc.}: CFString
+
+proc copyAttribute*(font: CTFont, attribute: CFString): CFObject {.importc: "CTFontCopyAttribute".}


### PR DESCRIPTION
- Add CFURLRef type alias and getFileSystemRepresentation proc to cfurl.nim
- Add kCTFontURLAttribute and copyAttribute to ctfont.nim

These bindings enable retrieving the file system URL of a font.