### PR TITLE
Add Core Graphics CGPath and CGImage bindings

### DIFF
--- a/darwin/core_graphics.nim
+++ b/darwin/core_graphics.nim
@@ -1,2 +1,2 @@
-import core_graphics / [cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform]
-export cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform
+import core_graphics / [cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage]
+export cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage

--- a/darwin/core_graphics/cgbitmap_context.nim
+++ b/darwin/core_graphics/cgbitmap_context.nim
@@ -1,5 +1,8 @@
-import cgcontext, cgcolor_space
+import cgcontext, cgcolor_space, cgimage
 
 proc CGBitmapContextCreate*(data: pointer,
     width, height, bitsPerComponent, bytesPerRow: csize,
     space: CGColorSpace, bitmapInfo: uint32): CGContext {.importc.}
+
+proc getData*(context: CGContext): pointer {.importc: "CGBitmapContextGetData".}
+proc createImage*(context: CGContext): CGImage {.importc: "CGBitmapContextCreateImage".}

--- a/darwin/core_graphics/cgcontext.nim
+++ b/darwin/core_graphics/cgcontext.nim
@@ -21,6 +21,8 @@ proc setCMYKStrokeColor*(c: CGContext, cy, m, y, k, a: CGFloat) {.importc: "CGCo
 
 proc showGlyphsAtPositions*(c: CGContext, glyphs: ptr CGGlyph, positions: ptr CGPoint, count: csize) {.importc: "CGContextShowGlyphsAtPositions".}
 
+proc fillRect*(c: CGContext, rect: CGRect) {.importc: "CGContextFillRect".}
+
 proc scaleCTM*(c: CGContext, sx, sy: CGFloat) {.importc: "CGContextScaleCTM".}
 proc translateCTM*(c: CGContext, tx, ty: CGFloat) {.importc: "CGContextTranslateCTM".}
 proc rotateCTM*(c: CGContext, angle: CGFloat) {.importc: "CGContextRotateCTM".}

--- a/darwin/core_graphics/cgimage.nim
+++ b/darwin/core_graphics/cgimage.nim
@@ -1,0 +1,124 @@
+import darwin / core_foundation / [cfbase, cfstring]
+import cgcolor_space, cggeometry
+
+type
+    CGImage* = ptr object of CFObject
+    CGDataProvider* = ptr object of CFObject
+
+    CGImageAlphaInfo* {.size: sizeof(uint32).} = enum
+        kCGImageAlphaNone
+        kCGImageAlphaPremultipliedLast
+        kCGImageAlphaPremultipliedFirst
+        kCGImageAlphaLast
+        kCGImageAlphaFirst
+        kCGImageAlphaNoneSkipLast
+        kCGImageAlphaNoneSkipFirst
+        kCGImageAlphaOnly
+
+    CGImageByteOrderInfo* {.size: sizeof(uint32).} = enum
+        kCGImageByteOrderMask = 0x7000
+        kCGImageByteOrderDefault = 0
+        kCGImageByteOrder16Little = 1 shl 12
+        kCGImageByteOrder32Little = 2 shl 12
+        kCGImageByteOrder16Big = 3 shl 12
+        kCGImageByteOrder32Big = 4 shl 12
+
+    CGImagePixelFormatInfo* {.size: sizeof(uint32).} = enum
+        kCGImagePixelFormatMask = 0xF0000
+        kCGImagePixelFormatPacked = 0
+        kCGImagePixelFormatRGB555 = 1 shl 16
+        kCGImagePixelFormatRGB565 = 2 shl 16
+        kCGImagePixelFormatRGB101010 = 3 shl 16
+        kCGImagePixelFormatRGBCIF10 = 4 shl 16
+
+    CGBitmapInfo* {.size: sizeof(uint32).} = enum
+        kCGBitmapAlphaInfoMask = 0x1F
+        kCGBitmapFloatInfoMask = 0xF00
+        kCGBitmapFloatComponents = 1 shl 8
+        kCGBitmapByteOrderMask = kCGImageByteOrderMask.ord
+        kCGBitmapByteOrderDefault = kCGImageByteOrderDefault.ord
+        kCGBitmapByteOrder16Little = kCGImageByteOrder16Little.ord
+        kCGBitmapByteOrder32Little = kCGImageByteOrder32Little.ord
+        kCGBitmapByteOrder16Big = kCGImageByteOrder16Big.ord
+        kCGBitmapByteOrder32Big = kCGImageByteOrder32Big.ord
+
+    CGColorRenderingIntent* {.size: sizeof(int32).} = enum
+        kCGRenderingIntentDefault
+        kCGRenderingIntentAbsoluteColorimetric
+        kCGRenderingIntentRelativeColorimetric
+        kCGRenderingIntentPerceptual
+        kCGRenderingIntentSaturation
+
+# Byte order host constants (computed at compile time)
+when system.cpuEndian == bigEndian:
+    const kCGBitmapByteOrder16Host* = kCGBitmapByteOrder16Big
+    const kCGBitmapByteOrder32Host* = kCGBitmapByteOrder32Big
+else:
+    const kCGBitmapByteOrder16Host* = kCGBitmapByteOrder16Little
+    const kCGBitmapByteOrder32Host* = kCGBitmapByteOrder32Little
+
+# Type ID
+proc CGImageGetTypeID*(): CFTypeID {.importc.}
+
+# Create functions - keep original C names
+proc CGImageCreate*(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow: csize,
+    space: CGColorSpace, bitmapInfo: CGBitmapInfo, provider: CGDataProvider,
+    decode: ptr CGFloat, shouldInterpolate: bool, intent: CGColorRenderingIntent): CGImage {.importc.}
+
+proc CGImageMaskCreate*(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow: csize,
+    provider: CGDataProvider, decode: ptr CGFloat, shouldInterpolate: bool): CGImage {.importc.}
+
+proc CGImageCreateCopy*(image: CGImage): CGImage {.importc.}
+
+proc CGImageCreateWithJPEGDataProvider*(source: CGDataProvider, decode: ptr CGFloat,
+    shouldInterpolate: bool, intent: CGColorRenderingIntent): CGImage {.importc.}
+
+proc CGImageCreateWithPNGDataProvider*(source: CGDataProvider, decode: ptr CGFloat,
+    shouldInterpolate: bool, intent: CGColorRenderingIntent): CGImage {.importc.}
+
+proc CGImageCreateWithImageInRect*(image: CGImage, rect: CGRect): CGImage {.importc.}
+
+proc CGImageCreateWithMask*(image: CGImage, mask: CGImage): CGImage {.importc.}
+
+proc CGImageCreateWithMaskingColors*(image: CGImage, components: ptr CGFloat): CGImage {.importc.}
+
+proc CGImageCreateCopyWithColorSpace*(image: CGImage, space: CGColorSpace): CGImage {.importc.}
+
+# HDR Content Headroom (macOS 15.0+, iOS 18.0+) - keep C names
+proc CGImageCreateWithContentHeadroom*(headroom: cfloat, width, height, bitsPerComponent,
+    bitsPerPixel, bytesPerRow: csize, space: CGColorSpace, bitmapInfo: CGBitmapInfo,
+    provider: CGDataProvider, decode: ptr CGFloat, shouldInterpolate: bool,
+    intent: CGColorRenderingIntent): CGImage {.importc.}
+
+proc CGImageCreateCopyWithContentHeadroom*(headroom: cfloat, image: CGImage): CGImage {.importc.}
+
+var kCGDefaultHDRImageContentHeadroom* {.importc.}: cfloat
+
+# Retain/Release - concise naming
+proc retain*(image: CGImage): CGImage {.importc: "CGImageRetain".}
+proc release*(image: CGImage) {.importc: "CGImageRelease".}
+
+# Image properties - concise naming for image as first parameter
+proc isMask*(image: CGImage): bool {.importc: "CGImageIsMask".}
+proc getWidth*(image: CGImage): csize {.importc: "CGImageGetWidth".}
+proc getHeight*(image: CGImage): csize {.importc: "CGImageGetHeight".}
+proc getBitsPerComponent*(image: CGImage): csize {.importc: "CGImageGetBitsPerComponent".}
+proc getBitsPerPixel*(image: CGImage): csize {.importc: "CGImageGetBitsPerPixel".}
+proc getBytesPerRow*(image: CGImage): csize {.importc: "CGImageGetBytesPerRow".}
+proc getColorSpace*(image: CGImage): CGColorSpace {.importc: "CGImageGetColorSpace".}
+proc getAlphaInfo*(image: CGImage): CGImageAlphaInfo {.importc: "CGImageGetAlphaInfo".}
+proc getDataProvider*(image: CGImage): CGDataProvider {.importc: "CGImageGetDataProvider".}
+proc getDecode*(image: CGImage): ptr CGFloat {.importc: "CGImageGetDecode".}
+proc getShouldInterpolate*(image: CGImage): bool {.importc: "CGImageGetShouldInterpolate".}
+proc getRenderingIntent*(image: CGImage): CGColorRenderingIntent {.importc: "CGImageGetRenderingIntent".}
+proc getBitmapInfo*(image: CGImage): CGBitmapInfo {.importc: "CGImageGetBitmapInfo".}
+proc getByteOrderInfo*(image: CGImage): CGImageByteOrderInfo {.importc: "CGImageGetByteOrderInfo".}
+proc getPixelFormatInfo*(image: CGImage): CGImagePixelFormatInfo {.importc: "CGImageGetPixelFormatInfo".}
+proc getContentHeadroom*(image: CGImage): cfloat {.importc: "CGImageGetContentHeadroom".}
+
+# Tone mapping (macOS 15.0+, iOS 18.0+) - concise naming
+proc shouldToneMap*(image: CGImage): bool {.importc: "CGImageShouldToneMap".}
+proc containsImageSpecificToneMappingMetadata*(image: CGImage): bool {.importc: "CGImageContainsImageSpecificToneMappingMetadata".}
+
+# UTType - concise naming
+proc getUTType*(image: CGImage): CFString {.importc: "CGImageGetUTType".}

--- a/darwin/core_graphics/cgpath.nim
+++ b/darwin/core_graphics/cgpath.nim
@@ -1,0 +1,91 @@
+import darwin / core_foundation / [cfbase, cfarray]
+import cggeometry, cgaffine_transform
+
+type
+    CGPath* = ptr object of CFObject
+    CGMutablePath* = ptr object of CGPath
+
+    CGLineJoin* {.size: sizeof(int32).} = enum
+        kCGLineJoinMiter
+        kCGLineJoinRound
+        kCGLineJoinBevel
+
+    CGLineCap* {.size: sizeof(int32).} = enum
+        kCGLineCapButt
+        kCGLineCapRound
+        kCGLineCapSquare
+
+    CGPathElementType* {.size: sizeof(int32).} = enum
+        kCGPathElementMoveToPoint
+        kCGPathElementAddLineToPoint
+        kCGPathElementAddQuadCurveToPoint
+        kCGPathElementAddCurveToPoint
+        kCGPathElementCloseSubpath
+
+    CGPathElement* {.bycopy.} = object
+        kind*: CGPathElementType
+        points*: ptr CGPoint
+
+    CGPathApplierFunction* = proc(info: pointer, element: ptr CGPathElement) {.cdecl.}
+
+# Type ID
+proc CGPathGetTypeID*(): CFTypeID {.importc.}
+
+# Create functions - keep original C names for create functions
+proc CGPathCreateMutable*(): CGMutablePath {.importc.}
+proc CGPathCreateCopy*(path: CGPath): CGPath {.importc.}
+proc CGPathCreateCopyByTransformingPath*(path: CGPath, transform: ptr CGAffineTransform): CGPath {.importc.}
+proc CGPathCreateMutableCopy*(path: CGPath): CGMutablePath {.importc.}
+proc CGPathCreateMutableCopyByTransformingPath*(path: CGPath, transform: ptr CGAffineTransform): CGMutablePath {.importc.}
+proc CGPathCreateWithRect*(rect: CGRect, transform: ptr CGAffineTransform): CGPath {.importc.}
+proc CGPathCreateWithEllipseInRect*(rect: CGRect, transform: ptr CGAffineTransform): CGPath {.importc.}
+proc CGPathCreateWithRoundedRect*(rect: CGRect, cornerWidth, cornerHeight: CGFloat, transform: ptr CGAffineTransform): CGPath {.importc.}
+
+# Retain/Release - concise naming
+proc retain*(path: CGPath): CGPath {.importc: "CGPathRetain".}
+proc release*(path: CGPath) {.importc: "CGPathRelease".}
+
+# Equality
+proc CGPathEqualToPath*(path1, path2: CGPath): bool {.importc.}
+
+# Path construction - concise naming for path as first parameter
+proc moveToPoint*(path: CGMutablePath, transform: ptr CGAffineTransform, x, y: CGFloat) {.importc: "CGPathMoveToPoint".}
+proc addLineToPoint*(path: CGMutablePath, transform: ptr CGAffineTransform, x, y: CGFloat) {.importc: "CGPathAddLineToPoint".}
+proc addQuadCurveToPoint*(path: CGMutablePath, transform: ptr CGAffineTransform, cpx, cpy, x, y: CGFloat) {.importc: "CGPathAddQuadCurveToPoint".}
+proc addCurveToPoint*(path: CGMutablePath, transform: ptr CGAffineTransform, cp1x, cp1y, cp2x, cp2y, x, y: CGFloat) {.importc: "CGPathAddCurveToPoint".}
+proc closeSubpath*(path: CGMutablePath) {.importc: "CGPathCloseSubpath".}
+
+# Path construction convenience functions - concise naming
+proc addRect*(path: CGMutablePath, transform: ptr CGAffineTransform, rect: CGRect) {.importc: "CGPathAddRect".}
+proc addRects*(path: CGMutablePath, transform: ptr CGAffineTransform, rects: ptr CGRect, count: csize) {.importc: "CGPathAddRects".}
+proc addLines*(path: CGMutablePath, transform: ptr CGAffineTransform, points: ptr CGPoint, count: csize) {.importc: "CGPathAddLines".}
+proc addEllipseInRect*(path: CGMutablePath, transform: ptr CGAffineTransform, rect: CGRect) {.importc: "CGPathAddEllipseInRect".}
+proc addRelativeArc*(path: CGMutablePath, transform: ptr CGAffineTransform, x, y, radius, startAngle, delta: CGFloat) {.importc: "CGPathAddRelativeArc".}
+proc addArc*(path: CGMutablePath, transform: ptr CGAffineTransform, x, y, radius, startAngle, endAngle: CGFloat, clockwise: bool) {.importc: "CGPathAddArc".}
+proc addArcToPoint*(path: CGMutablePath, transform: ptr CGAffineTransform, x1, y1, x2, y2, radius: CGFloat) {.importc: "CGPathAddArcToPoint".}
+proc addRoundedRect*(path: CGMutablePath, transform: ptr CGAffineTransform, rect: CGRect, cornerWidth, cornerHeight: CGFloat) {.importc: "CGPathAddRoundedRect".}
+
+# Path information - concise naming
+proc isEmpty*(path: CGPath): bool {.importc: "CGPathIsEmpty".}
+proc isRect*(path: CGPath, rect: ptr CGRect): bool {.importc: "CGPathIsRect".}
+proc getCurrentPoint*(path: CGPath): CGPoint {.importc: "CGPathGetCurrentPoint".}
+proc getBoundingBox*(path: CGPath): CGRect {.importc: "CGPathGetBoundingBox".}
+proc getPathBoundingBox*(path: CGPath): CGRect {.importc: "CGPathGetPathBoundingBox".}
+
+# Path operations - concise naming
+proc containsPoint*(path: CGPath, transform: ptr CGAffineTransform, point: CGPoint, eoFill: bool): bool {.importc: "CGPathContainsPoint".}
+
+# Apply function - concise naming
+proc apply*(path: CGPath, info: pointer, function: CGPathApplierFunction) {.importc: "CGPathApply".}
+
+# Path modifications (macOS 13.0+, iOS 16.0+) - keep C names for create functions
+proc CGPathCreateCopyByNormalizing*(path: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyByUnioningPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyByIntersectingPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyBySubtractingPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyBySymmetricDifferenceOfPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyOfLineBySubtractingPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateCopyOfLineByIntersectingPath*(path, maskPath: CGPath, evenOddFillRule: bool): CGPath {.importc.}
+proc CGPathCreateSeparateComponents*(path: CGPath, evenOddFillRule: bool): CFArray {.importc.}
+proc CGPathCreateCopyByFlattening*(path: CGPath, flatteningThreshold: CGFloat): CGPath {.importc.}
+proc CGPathIntersectsPath*(path1, path2: CGPath, evenOddFillRule: bool): bool {.importc.}


### PR DESCRIPTION
- Add complete CGPath bindings (cgpath.nim):
  - Types: CGPath, CGMutablePath, CGLineJoin, CGLineCap, CGPathElementType, CGPathElement
  - Create functions: CGPathCreateMutable, CGPathCreateWithRect, etc.
  - Path operations: moveToPoint, addLineToPoint, addRect, addArc, etc.
  - Path queries: isEmpty, getBoundingBox, containsPoint, etc.
  - Path modifications (macOS 13+): union, intersect, subtract, etc.

- Add complete CGImage bindings (cgimage.nim):
  - Types: CGImage, CGDataProvider, CGImageAlphaInfo, CGBitmapInfo, etc.
  - Create functions: CGImageCreate, CGImageMaskCreate, CGImageCreateWithJPEGDataProvider, etc.
  - Image properties: getWidth, getHeight, getColorSpace, getAlphaInfo, etc.
  - HDR support (macOS 15+): content headroom functions

- Update cgcontext.nim: add fillRect function
- Update cgbitmap_context.nim: add getData and createImage functions
- Update core_graphics.nim: export cgpath and cgimage modules

Naming style:
- Concise naming for functions with module type as first parameter (retain, release, addRect)
- C function names for create functions and global functions (CGPathCreateMutable, CGPathGetTypeID)