### PR TITLE
Add Vision framework bindings

### DIFF
--- a/darwin/core_video/cvbuffer.nim
+++ b/darwin/core_video/cvbuffer.nim
@@ -1,0 +1,6 @@
+# CoreVideo Buffer types
+
+type
+  CVBufferRef* = distinct pointer        # struct __CVBuffer *
+  CVImageBufferRef* = CVBufferRef        # alias for CVBufferRef
+  CVPixelBufferRef* = CVBufferRef        # alias for CVBufferRef

--- a/darwin/foundation/nsindexset.nim
+++ b/darwin/foundation/nsindexset.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+  NSIndexSet* = ptr object of NSObject

--- a/darwin/foundation/nsuuid.nim
+++ b/darwin/foundation/nsuuid.nim
@@ -1,0 +1,7 @@
+import ../objc/runtime
+import nsstring
+
+type
+  NSUUID* = ptr object of NSObject
+
+proc UUIDString*(self: NSUUID): NSString {.objc: "UUIDString".}

--- a/darwin/vision.nim
+++ b/darwin/vision.nim
@@ -1,0 +1,13 @@
+import vision / [vntypes, vnerror, vnrequest, vnrequesthandler, vnobservation,
+    vndetectfacerectanglesrequest, vndetectfacelandmarksrequest, vnrecognizetextrequest, 
+    vndetectbarcodesrequest, vndetectrectanglesrequest,
+    vngenerateattentionbasedsaliencyimagerequest,
+    vngeometry, vndetectedpoint]
+
+export vntypes, vnerror, vnrequest, vnrequesthandler, vnobservation,
+    vndetectfacerectanglesrequest, vndetectfacelandmarksrequest, vnrecognizetextrequest, 
+    vndetectbarcodesrequest, vndetectrectanglesrequest,
+    vngenerateattentionbasedsaliencyimagerequest,
+    vngeometry, vndetectedpoint
+
+{.passL: "-framework Vision".}

--- a/darwin/vision/vndetectbarcodesrequest.nim
+++ b/darwin/vision/vndetectbarcodesrequest.nim
@@ -9,14 +9,14 @@ type
   VNDetectBarcodesRequest* = ptr object of VNImageBasedRequest
 
 # VNDetectBarcodesRequest class methods
-proc supportedSymbologies*(self: typedesc[VNDetectBarcodesRequest]): NSArray {.objc: "supportedSymbologies".}
+proc supportedSymbologies*(self: typedesc[VNDetectBarcodesRequest]): NSArray[NSString] {.objc: "supportedSymbologies".}  # NSArray<VNBarcodeSymbology>
 
 # VNDetectBarcodesRequest instance methods
 proc init*(self: VNDetectBarcodesRequest): VNDetectBarcodesRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNDetectBarcodesRequest, handler: pointer): VNDetectBarcodesRequest {.objc: "initWithCompletionHandler:".}
-proc supportedSymbologiesAndReturnError*(self: VNDetectBarcodesRequest, error: ptr NSError = nil): NSArray {.objc: "supportedSymbologiesAndReturnError:".}
-proc symbologies*(self: VNDetectBarcodesRequest): NSArray {.objc: "symbologies".}
-proc setSymbologies*(self: VNDetectBarcodesRequest, symbologies: NSArray) {.objc: "setSymbologies:".}
+proc supportedSymbologiesAndReturnError*(self: VNDetectBarcodesRequest, error: ptr NSError = nil): NSArray[NSString] {.objc: "supportedSymbologiesAndReturnError:".}  # NSArray<VNBarcodeSymbology>
+proc symbologies*(self: VNDetectBarcodesRequest): NSArray[NSString] {.objc: "symbologies".}  # NSArray<VNBarcodeSymbology>
+proc setSymbologies*(self: VNDetectBarcodesRequest, symbologies: NSArray[NSString]) {.objc: "setSymbologies:".}  # NSArray<VNBarcodeSymbology>
 proc coalesceCompositeSymbologies*(self: VNDetectBarcodesRequest): bool {.objc: "coalesceCompositeSymbologies".}
 proc setCoalesceCompositeSymbologies*(self: VNDetectBarcodesRequest, value: bool) {.objc: "setCoalesceCompositeSymbologies:".}
-proc results*(self: VNDetectBarcodesRequest): NSArray {.objc: "results".}  # NSArray<VNBarcodeObservation*>
+proc results*(self: VNDetectBarcodesRequest): NSArray[VNBarcodeObservation] {.objc: "results".}

--- a/darwin/vision/vndetectbarcodesrequest.nim
+++ b/darwin/vision/vndetectbarcodesrequest.nim
@@ -1,0 +1,22 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nserror
+import vnrequest
+import vnobservation
+import vntypes
+
+type
+  VNDetectBarcodesRequest* = ptr object of VNImageBasedRequest
+
+# VNDetectBarcodesRequest class methods
+proc supportedSymbologies*(self: typedesc[VNDetectBarcodesRequest]): NSArray {.objc: "supportedSymbologies".}
+
+# VNDetectBarcodesRequest instance methods
+proc init*(self: VNDetectBarcodesRequest): VNDetectBarcodesRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNDetectBarcodesRequest, handler: pointer): VNDetectBarcodesRequest {.objc: "initWithCompletionHandler:".}
+proc supportedSymbologiesAndReturnError*(self: VNDetectBarcodesRequest, error: ptr NSError = nil): NSArray {.objc: "supportedSymbologiesAndReturnError:".}
+proc symbologies*(self: VNDetectBarcodesRequest): NSArray {.objc: "symbologies".}
+proc setSymbologies*(self: VNDetectBarcodesRequest, symbologies: NSArray) {.objc: "setSymbologies:".}
+proc coalesceCompositeSymbologies*(self: VNDetectBarcodesRequest): bool {.objc: "coalesceCompositeSymbologies".}
+proc setCoalesceCompositeSymbologies*(self: VNDetectBarcodesRequest, value: bool) {.objc: "setCoalesceCompositeSymbologies:".}
+proc results*(self: VNDetectBarcodesRequest): NSArray {.objc: "results".}  # NSArray<VNBarcodeObservation*>

--- a/darwin/vision/vndetectedpoint.nim
+++ b/darwin/vision/vndetectedpoint.nim
@@ -1,0 +1,14 @@
+import ../objc/runtime
+import ../foundation/nsstring
+import vntypes
+import vngeometry
+
+type
+  VNDetectedPoint* = ptr object of VNPoint
+  VNRecognizedPoint* = ptr object of VNDetectedPoint
+
+# VNDetectedPoint methods
+proc confidence*(self: VNDetectedPoint): VNConfidence {.objc: "confidence".}
+
+# VNRecognizedPoint methods
+proc identifier*(self: VNRecognizedPoint): VNRecognizedPointKey {.objc: "identifier".}

--- a/darwin/vision/vndetectfacelandmarksrequest.nim
+++ b/darwin/vision/vndetectfacelandmarksrequest.nim
@@ -1,0 +1,18 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import vnrequest
+import vnobservation
+
+type
+  VNDetectFaceLandmarksRequest* = ptr object of VNImageBasedRequest
+
+# VNDetectFaceLandmarksRequest methods
+proc init*(self: VNDetectFaceLandmarksRequest): VNDetectFaceLandmarksRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNDetectFaceLandmarksRequest, handler: pointer): VNDetectFaceLandmarksRequest {.objc: "initWithCompletionHandler:".}
+proc results*(self: VNDetectFaceLandmarksRequest): NSArray {.objc: "results".}  # NSArray<VNFaceObservation*>
+
+# Constants
+const
+  VNDetectFaceLandmarksRequestRevision1* = 1.NSUInteger
+  VNDetectFaceLandmarksRequestRevision2* = 2.NSUInteger
+  VNDetectFaceLandmarksRequestRevision3* = 3.NSUInteger

--- a/darwin/vision/vndetectfacelandmarksrequest.nim
+++ b/darwin/vision/vndetectfacelandmarksrequest.nim
@@ -9,7 +9,7 @@ type
 # VNDetectFaceLandmarksRequest methods
 proc init*(self: VNDetectFaceLandmarksRequest): VNDetectFaceLandmarksRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNDetectFaceLandmarksRequest, handler: pointer): VNDetectFaceLandmarksRequest {.objc: "initWithCompletionHandler:".}
-proc results*(self: VNDetectFaceLandmarksRequest): NSArray {.objc: "results".}  # NSArray<VNFaceObservation*>
+proc results*(self: VNDetectFaceLandmarksRequest): NSArray[VNFaceObservation] {.objc: "results".}
 
 # Constants
 const

--- a/darwin/vision/vndetectfacerectanglesrequest.nim
+++ b/darwin/vision/vndetectfacerectanglesrequest.nim
@@ -1,0 +1,12 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import vnrequest
+import vnobservation
+
+type
+  VNDetectFaceRectanglesRequest* = ptr object of VNImageBasedRequest
+
+# VNDetectFaceRectanglesRequest methods
+proc init*(self: VNDetectFaceRectanglesRequest): VNDetectFaceRectanglesRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNDetectFaceRectanglesRequest, handler: pointer): VNDetectFaceRectanglesRequest {.objc: "initWithCompletionHandler:".}
+proc results*(self: VNDetectFaceRectanglesRequest): NSArray {.objc: "results".}  # NSArray<VNFaceObservation*>

--- a/darwin/vision/vndetectfacerectanglesrequest.nim
+++ b/darwin/vision/vndetectfacerectanglesrequest.nim
@@ -9,4 +9,4 @@ type
 # VNDetectFaceRectanglesRequest methods
 proc init*(self: VNDetectFaceRectanglesRequest): VNDetectFaceRectanglesRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNDetectFaceRectanglesRequest, handler: pointer): VNDetectFaceRectanglesRequest {.objc: "initWithCompletionHandler:".}
-proc results*(self: VNDetectFaceRectanglesRequest): NSArray {.objc: "results".}  # NSArray<VNFaceObservation*>
+proc results*(self: VNDetectFaceRectanglesRequest): NSArray[VNFaceObservation] {.objc: "results".}

--- a/darwin/vision/vndetectrectanglesrequest.nim
+++ b/darwin/vision/vndetectrectanglesrequest.nim
@@ -1,0 +1,31 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import vnrequest
+import vnobservation
+import vntypes
+
+type
+  VNDetectRectanglesRequest* = ptr object of VNImageBasedRequest
+
+# VNDetectRectanglesRequest methods
+proc init*(self: VNDetectRectanglesRequest): VNDetectRectanglesRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNDetectRectanglesRequest, handler: pointer): VNDetectRectanglesRequest {.objc: "initWithCompletionHandler:".}
+proc results*(self: VNDetectRectanglesRequest): NSArray {.objc: "results".}  # NSArray<VNRectangleObservation*>
+
+# Properties
+proc minimumAspectRatio*(self: VNDetectRectanglesRequest): VNAspectRatio {.objc: "minimumAspectRatio".}
+proc setMinimumAspectRatio*(self: VNDetectRectanglesRequest, value: VNAspectRatio) {.objc: "setMinimumAspectRatio:".}
+proc maximumAspectRatio*(self: VNDetectRectanglesRequest): VNAspectRatio {.objc: "maximumAspectRatio".}
+proc setMaximumAspectRatio*(self: VNDetectRectanglesRequest, value: VNAspectRatio) {.objc: "setMaximumAspectRatio:".}
+proc quadratureTolerance*(self: VNDetectRectanglesRequest): VNDegrees {.objc: "quadratureTolerance".}
+proc setQuadratureTolerance*(self: VNDetectRectanglesRequest, value: VNDegrees) {.objc: "setQuadratureTolerance:".}
+proc minimumSize*(self: VNDetectRectanglesRequest): cfloat {.objc: "minimumSize".}
+proc setMinimumSize*(self: VNDetectRectanglesRequest, value: cfloat) {.objc: "setMinimumSize:".}
+proc minimumConfidence*(self: VNDetectRectanglesRequest): VNConfidence {.objc: "minimumConfidence".}
+proc setMinimumConfidence*(self: VNDetectRectanglesRequest, value: VNConfidence) {.objc: "setMinimumConfidence:".}
+proc maximumObservations*(self: VNDetectRectanglesRequest): NSUInteger {.objc: "maximumObservations".}
+proc setMaximumObservations*(self: VNDetectRectanglesRequest, value: NSUInteger) {.objc: "setMaximumObservations:".}
+
+# Constants
+const
+  VNDetectRectanglesRequestRevision1* = 1.NSUInteger

--- a/darwin/vision/vndetectrectanglesrequest.nim
+++ b/darwin/vision/vndetectrectanglesrequest.nim
@@ -10,7 +10,7 @@ type
 # VNDetectRectanglesRequest methods
 proc init*(self: VNDetectRectanglesRequest): VNDetectRectanglesRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNDetectRectanglesRequest, handler: pointer): VNDetectRectanglesRequest {.objc: "initWithCompletionHandler:".}
-proc results*(self: VNDetectRectanglesRequest): NSArray {.objc: "results".}  # NSArray<VNRectangleObservation*>
+proc results*(self: VNDetectRectanglesRequest): NSArray[VNRectangleObservation] {.objc: "results".}
 
 # Properties
 proc minimumAspectRatio*(self: VNDetectRectanglesRequest): VNAspectRatio {.objc: "minimumAspectRatio".}

--- a/darwin/vision/vnerror.nim
+++ b/darwin/vision/vnerror.nim
@@ -1,0 +1,33 @@
+import ../objc/runtime
+import ../foundation/nsstring
+
+# Error domain
+proc vnErrorDomain*(): NSString {.inline.} = @"VNErrorDomain"
+
+# Error codes
+type
+  VNErrorCode* {.size: sizeof(cint).} = enum
+    vnErrorTuriCoreErrorCode = -1
+    vnErrorOK = 0
+    vnErrorRequestCancelled = 1
+    vnErrorInvalidFormat = 2
+    vnErrorOperationFailed = 3
+    vnErrorOutOfBoundsError = 4
+    vnErrorInvalidOption = 5
+    vnErrorIOError = 6
+    vnErrorMissingOption = 7
+    vnErrorNotImplemented = 8
+    vnErrorInternalError = 9
+    vnErrorOutOfMemory = 10
+    vnErrorUnknownError = 11
+    vnErrorInvalidOperation = 12
+    vnErrorInvalidImage = 13
+    vnErrorInvalidArgument = 14
+    vnErrorInvalidModel = 15
+    vnErrorUnsupportedRevision = 16
+    vnErrorDataUnavailable = 17
+    vnErrorTimeStampNotFound = 18
+    vnErrorUnsupportedRequest = 19
+    vnErrorTimeout = 20
+    vnErrorUnsupportedComputeStage = 21
+    vnErrorUnsupportedComputeDevice = 22

--- a/darwin/vision/vngenerateattentionbasedsaliencyimagerequest.nim
+++ b/darwin/vision/vngenerateattentionbasedsaliencyimagerequest.nim
@@ -9,4 +9,4 @@ type
 # VNGenerateAttentionBasedSaliencyImageRequest methods
 proc init*(self: VNGenerateAttentionBasedSaliencyImageRequest): VNGenerateAttentionBasedSaliencyImageRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNGenerateAttentionBasedSaliencyImageRequest, handler: pointer): VNGenerateAttentionBasedSaliencyImageRequest {.objc: "initWithCompletionHandler:".}
-proc results*(self: VNGenerateAttentionBasedSaliencyImageRequest): NSArray {.objc: "results".}  # NSArray<VNSaliencyImageObservation*>
+proc results*(self: VNGenerateAttentionBasedSaliencyImageRequest): NSArray[VNSaliencyImageObservation] {.objc: "results".}

--- a/darwin/vision/vngenerateattentionbasedsaliencyimagerequest.nim
+++ b/darwin/vision/vngenerateattentionbasedsaliencyimagerequest.nim
@@ -1,0 +1,12 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import vnrequest
+import vnobservation
+
+type
+  VNGenerateAttentionBasedSaliencyImageRequest* = ptr object of VNImageBasedRequest
+
+# VNGenerateAttentionBasedSaliencyImageRequest methods
+proc init*(self: VNGenerateAttentionBasedSaliencyImageRequest): VNGenerateAttentionBasedSaliencyImageRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNGenerateAttentionBasedSaliencyImageRequest, handler: pointer): VNGenerateAttentionBasedSaliencyImageRequest {.objc: "initWithCompletionHandler:".}
+proc results*(self: VNGenerateAttentionBasedSaliencyImageRequest): NSArray {.objc: "results".}  # NSArray<VNSaliencyImageObservation*>

--- a/darwin/vision/vngeometry.nim
+++ b/darwin/vision/vngeometry.nim
@@ -1,0 +1,65 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nsstring
+import ../foundation/nserror
+import ../core_graphics/cggeometry
+
+type
+  VNPoint* = ptr object of NSObject
+  VNPoint3D* = ptr object of NSObject
+  VNVector* = ptr object of NSObject
+  VNCircle* = ptr object of NSObject
+  VNContour* = ptr object of NSObject
+
+# VNPoint methods
+proc zeroPoint*(self: typedesc[VNPoint]): VNPoint {.objc: "zeroPoint".}
+proc pointByApplyingVector*(self: typedesc[VNPoint], vector: VNVector, toPoint: VNPoint): VNPoint {.objc: "pointByApplyingVector:toPoint:".}
+proc distanceBetween*(self: typedesc[VNPoint], point1: VNPoint, point2: VNPoint): cdouble {.objc: "distanceBetweenPoint:point:".}
+proc init*(self: VNPoint, x: cdouble, y: cdouble): VNPoint {.objc: "initWithX:y:".}
+proc init*(self: VNPoint, location: CGPoint): VNPoint {.objc: "initWithLocation:".}
+proc location*(self: VNPoint): CGPoint {.objc: "location".}
+proc x*(self: VNPoint): cdouble {.objc: "x".}
+proc y*(self: VNPoint): cdouble {.objc: "y".}
+proc distanceToPoint*(self: VNPoint, point: VNPoint): cdouble {.objc: "distanceToPoint:".}
+
+# VNPoint3D methods
+proc init*(self: VNPoint3D, position: pointer): VNPoint3D {.objc: "initWithPosition:".}  # simd_float4x4
+proc position*(self: VNPoint3D): pointer {.objc: "position".}  # simd_float4x4
+
+# VNVector methods
+proc zeroVector*(self: typedesc[VNVector]): VNVector {.objc: "zeroVector".}
+proc unitVectorFor*(self: typedesc[VNVector], vector: VNVector): VNVector {.objc: "unitVectorForVector:".}
+proc vectorByMultiplying*(self: typedesc[VNVector], vector: VNVector, byScalar: cdouble): VNVector {.objc: "vectorByMultiplyingVector:byScalar:".}
+proc vectorByAdding*(self: typedesc[VNVector], v1: VNVector, toVector: VNVector): VNVector {.objc: "vectorByAddingVector:toVector:".}
+proc vectorBySubtracting*(self: typedesc[VNVector], v1: VNVector, fromVector: VNVector): VNVector {.objc: "vectorBySubtractingVector:fromVector:".}
+proc dotProduct*(self: typedesc[VNVector], v1: VNVector, v2: VNVector): cdouble {.objc: "dotProductOfVector:vector:".}
+proc initWithComponents*(self: VNVector, xComponent: cdouble, yComponent: cdouble): VNVector {.objc: "initWithXComponent:yComponent:".}
+proc initWithPolar*(self: VNVector, r: cdouble, theta: cdouble): VNVector {.objc: "initWithR:theta:".}
+proc initWithHeadAndTail*(self: VNVector, head: VNPoint, tail: VNPoint): VNVector {.objc: "initWithVectorHead:tail:".}
+proc x*(self: VNVector): cdouble {.objc: "x".}
+proc y*(self: VNVector): cdouble {.objc: "y".}
+proc r*(self: VNVector): cdouble {.objc: "r".}
+proc theta*(self: VNVector): cdouble {.objc: "theta".}
+proc length*(self: VNVector): cdouble {.objc: "length".}
+proc squaredLength*(self: VNVector): cdouble {.objc: "squaredLength".}
+
+# VNCircle methods
+proc zeroCircle*(self: typedesc[VNCircle]): VNCircle {.objc: "zeroCircle".}
+proc initWithCenterRadius*(self: VNCircle, center: VNPoint, radius: cdouble): VNCircle {.objc: "initWithCenter:radius:".}
+proc initWithCenterDiameter*(self: VNCircle, center: VNPoint, diameter: cdouble): VNCircle {.objc: "initWithCenter:diameter:".}
+proc containsPoint*(self: VNCircle, point: VNPoint): bool {.objc: "containsPoint:".}
+proc containsPoint*(self: VNCircle, point: VNPoint, inCircumferentialRingOfWidth: cdouble): bool {.objc: "containsPoint:inCircumferentialRingOfWidth:".}
+proc center*(self: VNCircle): VNPoint {.objc: "center".}
+proc radius*(self: VNCircle): cdouble {.objc: "radius".}
+proc diameter*(self: VNCircle): cdouble {.objc: "diameter".}
+
+# VNContour methods
+proc indexPath*(self: VNContour): pointer {.objc: "indexPath".}  # NSIndexPath
+proc childContourCount*(self: VNContour): NSInteger {.objc: "childContourCount".}
+proc childContours*(self: VNContour): NSArray {.objc: "childContours".}
+proc childContourAtIndex*(self: VNContour, childContourIndex: NSUInteger, error: ptr NSError = nil): VNContour {.objc: "childContourAtIndex:error:".}
+proc pointCount*(self: VNContour): NSInteger {.objc: "pointCount".}
+proc normalizedPoints*(self: VNContour): pointer {.objc: "normalizedPoints".}  # simd_float2 const *
+proc normalizedPath*(self: VNContour): pointer {.objc: "normalizedPath".}  # CGPathRef
+proc aspectRatio*(self: VNContour): cfloat {.objc: "aspectRatio".}
+proc polygonApproximation*(self: VNContour, epsilon: cfloat, error: ptr NSError = nil): VNContour {.objc: "polygonApproximationWithEpsilon:error:".}

--- a/darwin/vision/vngeometry.nim
+++ b/darwin/vision/vngeometry.nim
@@ -56,7 +56,7 @@ proc diameter*(self: VNCircle): cdouble {.objc: "diameter".}
 # VNContour methods
 proc indexPath*(self: VNContour): pointer {.objc: "indexPath".}  # NSIndexPath
 proc childContourCount*(self: VNContour): NSInteger {.objc: "childContourCount".}
-proc childContours*(self: VNContour): NSArray {.objc: "childContours".}
+proc childContours*(self: VNContour): NSArray[VNContour] {.objc: "childContours".}
 proc childContourAtIndex*(self: VNContour, childContourIndex: NSUInteger, error: ptr NSError = nil): VNContour {.objc: "childContourAtIndex:error:".}
 proc pointCount*(self: VNContour): NSInteger {.objc: "pointCount".}
 proc normalizedPoints*(self: VNContour): pointer {.objc: "normalizedPoints".}  # simd_float2 const *

--- a/darwin/vision/vnobservation.nim
+++ b/darwin/vision/vnobservation.nim
@@ -1,0 +1,166 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nsstring
+import ../foundation/nsdata
+import ../foundation/nsurl
+import ../foundation/nsuuid
+import ../foundation/nsindexset
+import ../foundation/nsdictionary
+import ../foundation/nsnumber
+import ../foundation/nsrange
+import ../foundation/nserror
+import ../core_graphics/cggeometry
+import ../core_graphics/cgaffine_transform
+import vntypes
+import vngeometry
+import vndetectedpoint
+
+type
+  VNObservation* = ptr object of NSObject
+  VNDetectedObjectObservation* = ptr object of VNObservation
+  VNFaceObservation* = ptr object of VNDetectedObjectObservation
+  VNClassificationObservation* = ptr object of VNObservation
+  VNRecognizedObjectObservation* = ptr object of VNDetectedObjectObservation
+  VNRectangleObservation* = ptr object of VNDetectedObjectObservation
+  VNTextObservation* = ptr object of VNRectangleObservation
+  VNRecognizedText* = ptr object of NSObject
+  VNRecognizedTextObservation* = ptr object of VNRectangleObservation
+  VNBarcodeObservation* = ptr object of VNRectangleObservation
+  VNHorizonObservation* = ptr object of VNObservation
+  VNImageAlignmentObservation* = ptr object of VNObservation
+  VNImageTranslationAlignmentObservation* = ptr object of VNImageAlignmentObservation
+  VNImageHomographicAlignmentObservation* = ptr object of VNImageAlignmentObservation
+  VNPixelBufferObservation* = ptr object of VNObservation
+  VNSaliencyImageObservation* = ptr object of VNPixelBufferObservation
+  VNFeaturePrintObservation* = ptr object of VNObservation
+  VNContoursObservation* = ptr object of VNObservation
+  VNRecognizedPointsObservation* = ptr object of VNObservation
+  VNHumanObservation* = ptr object of VNDetectedObjectObservation
+  VNInstanceMaskObservation* = ptr object of VNObservation
+  VNAnimalBodyPoseObservation* = ptr object of VNRecognizedPointsObservation
+  VNRecognizedPoints3DObservation* = ptr object of VNObservation
+  VNHumanBodyPose3DObservation* = ptr object of VNRecognizedPoints3DObservation
+
+# VNObservation methods
+proc uuid*(self: VNObservation): NSUUID {.objc: "uuid".}
+proc confidence*(self: VNObservation): VNConfidence {.objc: "confidence".}
+
+# VNDetectedObjectObservation methods - using overloading
+proc observationWithBoundingBox*(self: typedesc[VNDetectedObjectObservation], boundingBox: CGRect): VNDetectedObjectObservation {.objc: "observationWithBoundingBox:".}
+proc observationWithBoundingBox*(self: typedesc[VNDetectedObjectObservation], requestRevision: NSUInteger, boundingBox: CGRect): VNDetectedObjectObservation {.objc: "observationWithRequestRevision:boundingBox:".}
+proc boundingBox*(self: VNDetectedObjectObservation): CGRect {.objc: "boundingBox".}
+
+# VNFaceObservation methods - using overloading
+proc faceObservationWithRequestRevision*(self: typedesc[VNFaceObservation], requestRevision: NSUInteger, boundingBox: CGRect, roll: NSNumber, yaw: NSNumber): VNFaceObservation {.objc: "faceObservationWithRequestRevision:boundingBox:roll:yaw:".}
+proc faceObservationWithRequestRevision*(self: typedesc[VNFaceObservation], requestRevision: NSUInteger, boundingBox: CGRect, roll: NSNumber, yaw: NSNumber, pitch: NSNumber): VNFaceObservation {.objc: "faceObservationWithRequestRevision:boundingBox:roll:yaw:pitch:".}
+proc landmarks*(self: VNFaceObservation): pointer {.objc: "landmarks".}
+proc faceCaptureQuality*(self: VNFaceObservation): NSNumber {.objc: "faceCaptureQuality".}
+proc roll*(self: VNFaceObservation): NSNumber {.objc: "roll".}
+proc yaw*(self: VNFaceObservation): NSNumber {.objc: "yaw".}
+proc pitch*(self: VNFaceObservation): NSNumber {.objc: "pitch".}
+
+# VNClassificationObservation methods
+proc identifier*(self: VNClassificationObservation): NSString {.objc: "identifier".}
+proc hasPrecisionRecallCurve*(self: VNClassificationObservation): bool {.objc: "hasPrecisionRecallCurve".}
+proc hasMinimumRecall*(self: VNClassificationObservation, minimumRecall: cfloat, forPrecision: cfloat): bool {.objc: "hasMinimumRecall:forPrecision:".}
+proc hasMinimumPrecision*(self: VNClassificationObservation, minimumPrecision: cfloat, forRecall: cfloat): bool {.objc: "hasMinimumPrecision:forRecall:".}
+
+# VNRecognizedObjectObservation methods
+proc labels*(self: VNRecognizedObjectObservation): NSArray {.objc: "labels".}
+
+# VNRectangleObservation methods
+proc rectangleObservationWithRequestRevision*(self: typedesc[VNRectangleObservation], requestRevision: NSUInteger, topLeft: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint, topRight: CGPoint): VNRectangleObservation {.objc: "rectangleObservationWithRequestRevision:topLeft:bottomLeft:bottomRight:topRight:".}
+proc rectangleObservationWithRequestRevision*(self: typedesc[VNRectangleObservation], requestRevision: NSUInteger, topLeft: CGPoint, topRight: CGPoint, bottomRight: CGPoint, bottomLeft: CGPoint): VNRectangleObservation {.objc: "rectangleObservationWithRequestRevision:topLeft:topRight:bottomRight:bottomLeft:".}
+proc topLeft*(self: VNRectangleObservation): CGPoint {.objc: "topLeft".}
+proc topRight*(self: VNRectangleObservation): CGPoint {.objc: "topRight".}
+proc bottomLeft*(self: VNRectangleObservation): CGPoint {.objc: "bottomLeft".}
+proc bottomRight*(self: VNRectangleObservation): CGPoint {.objc: "bottomRight".}
+
+# VNTextObservation methods
+proc characterBoxes*(self: VNTextObservation): NSArray {.objc: "characterBoxes".}
+
+# VNRecognizedText methods
+proc string*(self: VNRecognizedText): NSString {.objc: "string".}
+proc boundingBoxForRange*(self: VNRecognizedText, range: NSRange, error: ptr NSError = nil): VNRectangleObservation {.objc: "boundingBoxForRange:error:".}
+
+# VNRecognizedTextObservation methods
+proc topCandidates*(self: VNRecognizedTextObservation, maxCandidateCount: NSUInteger): NSArray {.objc: "topCandidates:".}
+
+# VNBarcodeObservation methods
+proc symbology*(self: VNBarcodeObservation): VNBarcodeSymbology {.objc: "symbology".}
+proc barcodeDescriptor*(self: VNBarcodeObservation): pointer {.objc: "barcodeDescriptor".}
+proc payloadStringValue*(self: VNBarcodeObservation): NSString {.objc: "payloadStringValue".}
+proc payloadData*(self: VNBarcodeObservation): NSData {.objc: "payloadData".}
+proc isGS1DataCarrier*(self: VNBarcodeObservation): bool {.objc: "isGS1DataCarrier".}
+proc isColorInverted*(self: VNBarcodeObservation): bool {.objc: "isColorInverted".}
+proc supplementalCompositeType*(self: VNBarcodeObservation): VNBarcodeCompositeType {.objc: "supplementalCompositeType".}
+proc supplementalPayloadString*(self: VNBarcodeObservation): NSString {.objc: "supplementalPayloadString".}
+proc supplementalPayloadData*(self: VNBarcodeObservation): NSData {.objc: "supplementalPayloadData".}
+
+# VNHorizonObservation methods
+proc transform*(self: VNHorizonObservation): CGAffineTransform {.objc: "transform".}
+proc angle*(self: VNHorizonObservation): CGFloat {.objc: "angle".}
+proc transformForImage*(self: VNHorizonObservation, width: csize_t, height: csize_t): CGAffineTransform {.objc: "transformForImageWidth:height:".}
+
+# VNImageTranslationAlignmentObservation methods
+proc alignmentTransform*(self: VNImageTranslationAlignmentObservation): CGAffineTransform {.objc: "alignmentTransform".}
+
+# VNImageHomographicAlignmentObservation methods
+proc warpTransform*(self: VNImageHomographicAlignmentObservation): pointer {.objc: "warpTransform".}  # matrix_float3x3
+
+# VNPixelBufferObservation methods
+proc pixelBuffer*(self: VNPixelBufferObservation): pointer {.objc: "pixelBuffer".}  # CVPixelBufferRef
+proc featureName*(self: VNPixelBufferObservation): NSString {.objc: "featureName".}
+
+# VNSaliencyImageObservation methods
+proc salientObjects*(self: VNSaliencyImageObservation): NSArray {.objc: "salientObjects".}
+
+# VNFeaturePrintObservation methods
+proc elementType*(self: VNFeaturePrintObservation): VNElementType {.objc: "elementType".}
+proc elementCount*(self: VNFeaturePrintObservation): NSUInteger {.objc: "elementCount".}
+proc data*(self: VNFeaturePrintObservation): NSData {.objc: "data".}
+proc computeDistance*(self: VNFeaturePrintObservation, outDistance: ptr cfloat, toFeaturePrint: VNFeaturePrintObservation, error: ptr NSError = nil): bool {.objc: "computeDistance:toFeaturePrintObservation:error:".}
+
+# VNContoursObservation methods
+proc contourCount*(self: VNContoursObservation): NSInteger {.objc: "contourCount".}
+proc contourAtIndex*(self: VNContoursObservation, contourIndex: NSInteger, error: ptr NSError = nil): pointer {.objc: "contourAtIndex:error:".}
+proc topLevelContourCount*(self: VNContoursObservation): NSInteger {.objc: "topLevelContourCount".}
+proc topLevelContours*(self: VNContoursObservation): NSArray {.objc: "topLevelContours".}
+proc contourAtIndexPath*(self: VNContoursObservation, indexPath: pointer, error: ptr NSError = nil): pointer {.objc: "contourAtIndexPath:error:".}
+proc normalizedPath*(self: VNContoursObservation): pointer {.objc: "normalizedPath".}  # CGPathRef
+
+# VNRecognizedPointsObservation methods
+proc availableKeys*(self: VNRecognizedPointsObservation): NSArray {.objc: "availableKeys".}
+proc availableGroupKeys*(self: VNRecognizedPointsObservation): NSArray {.objc: "availableGroupKeys".}
+proc recognizedPointForKey*(self: VNRecognizedPointsObservation, pointKey: VNRecognizedPointKey, error: ptr NSError = nil): VNRecognizedPoint {.objc: "recognizedPointForKey:error:".}
+proc recognizedPointsForGroupKey*(self: VNRecognizedPointsObservation, groupKey: VNRecognizedPointGroupKey, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForGroupKey:error:".}
+
+# VNHumanObservation methods
+proc upperBodyOnly*(self: VNHumanObservation): bool {.objc: "upperBodyOnly".}
+
+# VNInstanceMaskObservation methods
+proc instanceMask*(self: VNInstanceMaskObservation): pointer {.objc: "instanceMask".}  # CVPixelBufferRef
+proc allInstances*(self: VNInstanceMaskObservation): NSIndexSet {.objc: "allInstances".}
+proc generateMaskForInstances*(self: VNInstanceMaskObservation, instances: NSIndexSet, error: ptr NSError = nil): pointer {.objc: "generateMaskForInstances:error:".}  # CVPixelBufferRef
+
+# VNAnimalBodyPoseObservation methods
+proc availableJointNames*(self: VNAnimalBodyPoseObservation): NSArray {.objc: "availableJointNames".}
+proc availableJointGroupNames*(self: VNAnimalBodyPoseObservation): NSArray {.objc: "availableJointGroupNames".}
+proc recognizedPointForJointName*(self: VNAnimalBodyPoseObservation, jointName: NSString, error: ptr NSError = nil): VNRecognizedPoint {.objc: "recognizedPointForJointName:error:".}
+proc recognizedPointsForJointsGroupName*(self: VNAnimalBodyPoseObservation, jointsGroupName: NSString, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForJointsGroupName:error:".}
+
+# VNRecognizedPoints3DObservation methods
+proc recognizedPointForKey*(self: VNRecognizedPoints3DObservation, pointKey: VNRecognizedPointKey, error: ptr NSError = nil): pointer {.objc: "recognizedPointForKey:error:".}  # VNRecognizedPoint3D
+proc recognizedPointsForGroupKey*(self: VNRecognizedPoints3DObservation, groupKey: VNRecognizedPointGroupKey, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForGroupKey:error:".}
+
+# VNHumanBodyPose3DObservation methods
+proc heightEstimation*(self: VNHumanBodyPose3DObservation): cint {.objc: "heightEstimation".}
+proc cameraOriginMatrix*(self: VNHumanBodyPose3DObservation): pointer {.objc: "cameraOriginMatrix".}  # simd_float4x4
+proc availableJointsGroupNames*(self: VNHumanBodyPose3DObservation): NSArray {.objc: "availableJointsGroupNames".}
+proc availableJointNames*(self: VNHumanBodyPose3DObservation): NSArray {.objc: "availableJointNames".}
+proc bodyHeight*(self: VNHumanBodyPose3DObservation): cfloat {.objc: "bodyHeight".}
+proc recognizedPointsForJointsGroupName*(self: VNHumanBodyPose3DObservation, jointsGroupName: NSString, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForJointsGroupName:error:".}
+proc recognizedPointForJointName*(self: VNHumanBodyPose3DObservation, jointName: NSString, error: ptr NSError = nil): pointer {.objc: "recognizedPointForJointName:error:".}  # VNHumanBodyRecognizedPoint3D
+proc pointInImageForJointName*(self: VNHumanBodyPose3DObservation, jointName: NSString, error: ptr NSError = nil): VNPoint {.objc: "pointInImageForJointName:error:".}
+proc parentJointNameForJointName*(self: VNHumanBodyPose3DObservation, jointName: NSString): NSString {.objc: "parentJointNameForJointName:".}
+proc getCameraRelativePosition*(self: VNHumanBodyPose3DObservation, modelPositionOut: pointer, forJointName: NSString, error: ptr NSError = nil): bool {.objc: "getCameraRelativePosition:forJointName:error:".}

--- a/darwin/vision/vnobservation.nim
+++ b/darwin/vision/vnobservation.nim
@@ -66,7 +66,7 @@ proc hasMinimumRecall*(self: VNClassificationObservation, minimumRecall: cfloat,
 proc hasMinimumPrecision*(self: VNClassificationObservation, minimumPrecision: cfloat, forRecall: cfloat): bool {.objc: "hasMinimumPrecision:forRecall:".}
 
 # VNRecognizedObjectObservation methods
-proc labels*(self: VNRecognizedObjectObservation): NSArray {.objc: "labels".}
+proc labels*(self: VNRecognizedObjectObservation): NSArray[VNClassificationObservation] {.objc: "labels".}
 
 # VNRectangleObservation methods
 proc rectangleObservationWithRequestRevision*(self: typedesc[VNRectangleObservation], requestRevision: NSUInteger, topLeft: CGPoint, bottomLeft: CGPoint, bottomRight: CGPoint, topRight: CGPoint): VNRectangleObservation {.objc: "rectangleObservationWithRequestRevision:topLeft:bottomLeft:bottomRight:topRight:".}
@@ -77,14 +77,14 @@ proc bottomLeft*(self: VNRectangleObservation): CGPoint {.objc: "bottomLeft".}
 proc bottomRight*(self: VNRectangleObservation): CGPoint {.objc: "bottomRight".}
 
 # VNTextObservation methods
-proc characterBoxes*(self: VNTextObservation): NSArray {.objc: "characterBoxes".}
+proc characterBoxes*(self: VNTextObservation): NSArray[VNRectangleObservation] {.objc: "characterBoxes".}
 
 # VNRecognizedText methods
 proc string*(self: VNRecognizedText): NSString {.objc: "string".}
 proc boundingBoxForRange*(self: VNRecognizedText, range: NSRange, error: ptr NSError = nil): VNRectangleObservation {.objc: "boundingBoxForRange:error:".}
 
 # VNRecognizedTextObservation methods
-proc topCandidates*(self: VNRecognizedTextObservation, maxCandidateCount: NSUInteger): NSArray {.objc: "topCandidates:".}
+proc topCandidates*(self: VNRecognizedTextObservation, maxCandidateCount: NSUInteger): NSArray[VNRecognizedText] {.objc: "topCandidates:".}
 
 # VNBarcodeObservation methods
 proc symbology*(self: VNBarcodeObservation): VNBarcodeSymbology {.objc: "symbology".}
@@ -113,7 +113,7 @@ proc pixelBuffer*(self: VNPixelBufferObservation): pointer {.objc: "pixelBuffer"
 proc featureName*(self: VNPixelBufferObservation): NSString {.objc: "featureName".}
 
 # VNSaliencyImageObservation methods
-proc salientObjects*(self: VNSaliencyImageObservation): NSArray {.objc: "salientObjects".}
+proc salientObjects*(self: VNSaliencyImageObservation): NSArray[VNRectangleObservation] {.objc: "salientObjects".}
 
 # VNFeaturePrintObservation methods
 proc elementType*(self: VNFeaturePrintObservation): VNElementType {.objc: "elementType".}
@@ -125,13 +125,13 @@ proc computeDistance*(self: VNFeaturePrintObservation, outDistance: ptr cfloat, 
 proc contourCount*(self: VNContoursObservation): NSInteger {.objc: "contourCount".}
 proc contourAtIndex*(self: VNContoursObservation, contourIndex: NSInteger, error: ptr NSError = nil): pointer {.objc: "contourAtIndex:error:".}
 proc topLevelContourCount*(self: VNContoursObservation): NSInteger {.objc: "topLevelContourCount".}
-proc topLevelContours*(self: VNContoursObservation): NSArray {.objc: "topLevelContours".}
+proc topLevelContours*(self: VNContoursObservation): NSArray[NSObject] {.objc: "topLevelContours".}  # NSArray<VNContour*>
 proc contourAtIndexPath*(self: VNContoursObservation, indexPath: pointer, error: ptr NSError = nil): pointer {.objc: "contourAtIndexPath:error:".}
 proc normalizedPath*(self: VNContoursObservation): pointer {.objc: "normalizedPath".}  # CGPathRef
 
 # VNRecognizedPointsObservation methods
-proc availableKeys*(self: VNRecognizedPointsObservation): NSArray {.objc: "availableKeys".}
-proc availableGroupKeys*(self: VNRecognizedPointsObservation): NSArray {.objc: "availableGroupKeys".}
+proc availableKeys*(self: VNRecognizedPointsObservation): NSArray[NSString] {.objc: "availableKeys".}  # NSArray<VNRecognizedPointKey>
+proc availableGroupKeys*(self: VNRecognizedPointsObservation): NSArray[NSString] {.objc: "availableGroupKeys".}  # NSArray<VNRecognizedPointGroupKey>
 proc recognizedPointForKey*(self: VNRecognizedPointsObservation, pointKey: VNRecognizedPointKey, error: ptr NSError = nil): VNRecognizedPoint {.objc: "recognizedPointForKey:error:".}
 proc recognizedPointsForGroupKey*(self: VNRecognizedPointsObservation, groupKey: VNRecognizedPointGroupKey, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForGroupKey:error:".}
 
@@ -144,8 +144,8 @@ proc allInstances*(self: VNInstanceMaskObservation): NSIndexSet {.objc: "allInst
 proc generateMaskForInstances*(self: VNInstanceMaskObservation, instances: NSIndexSet, error: ptr NSError = nil): pointer {.objc: "generateMaskForInstances:error:".}  # CVPixelBufferRef
 
 # VNAnimalBodyPoseObservation methods
-proc availableJointNames*(self: VNAnimalBodyPoseObservation): NSArray {.objc: "availableJointNames".}
-proc availableJointGroupNames*(self: VNAnimalBodyPoseObservation): NSArray {.objc: "availableJointGroupNames".}
+proc availableJointNames*(self: VNAnimalBodyPoseObservation): NSArray[NSString] {.objc: "availableJointNames".}  # NSArray<VNAnimalBodyPoseObservationJointName>
+proc availableJointGroupNames*(self: VNAnimalBodyPoseObservation): NSArray[NSString] {.objc: "availableJointGroupNames".}  # NSArray<VNAnimalBodyPoseObservationJointsGroupName>
 proc recognizedPointForJointName*(self: VNAnimalBodyPoseObservation, jointName: NSString, error: ptr NSError = nil): VNRecognizedPoint {.objc: "recognizedPointForJointName:error:".}
 proc recognizedPointsForJointsGroupName*(self: VNAnimalBodyPoseObservation, jointsGroupName: NSString, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForJointsGroupName:error:".}
 
@@ -156,8 +156,8 @@ proc recognizedPointsForGroupKey*(self: VNRecognizedPoints3DObservation, groupKe
 # VNHumanBodyPose3DObservation methods
 proc heightEstimation*(self: VNHumanBodyPose3DObservation): cint {.objc: "heightEstimation".}
 proc cameraOriginMatrix*(self: VNHumanBodyPose3DObservation): pointer {.objc: "cameraOriginMatrix".}  # simd_float4x4
-proc availableJointsGroupNames*(self: VNHumanBodyPose3DObservation): NSArray {.objc: "availableJointsGroupNames".}
-proc availableJointNames*(self: VNHumanBodyPose3DObservation): NSArray {.objc: "availableJointNames".}
+proc availableJointsGroupNames*(self: VNHumanBodyPose3DObservation): NSArray[NSString] {.objc: "availableJointsGroupNames".}  # NSArray<VNHumanBodyPose3DObservationJointsGroupName>
+proc availableJointNames*(self: VNHumanBodyPose3DObservation): NSArray[NSString] {.objc: "availableJointNames".}  # NSArray<VNHumanBodyPose3DObservationJointName>
 proc bodyHeight*(self: VNHumanBodyPose3DObservation): cfloat {.objc: "bodyHeight".}
 proc recognizedPointsForJointsGroupName*(self: VNHumanBodyPose3DObservation, jointsGroupName: NSString, error: ptr NSError = nil): NSDictionary {.objc: "recognizedPointsForJointsGroupName:error:".}
 proc recognizedPointForJointName*(self: VNHumanBodyPose3DObservation, jointName: NSString, error: ptr NSError = nil): pointer {.objc: "recognizedPointForJointName:error:".}  # VNHumanBodyRecognizedPoint3D

--- a/darwin/vision/vnrecognizetextrequest.nim
+++ b/darwin/vision/vnrecognizetextrequest.nim
@@ -1,0 +1,35 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nserror
+import vnrequest
+import vnobservation
+import vntypes
+
+type
+  VNRecognizeTextRequest* = ptr object of VNImageBasedRequest
+
+# VNRecognizeTextRequest class methods
+proc supportedRecognitionLanguagesForTextRecognitionLevelRevisionError*(self: typedesc[VNRecognizeTextRequest], recognitionLevel: VNRequestTextRecognitionLevel, requestRevision: NSUInteger, error: ptr NSError = nil): NSArray {.objc: "supportedRecognitionLanguagesForTextRecognitionLevel:revision:error:".}
+
+# VNRecognizeTextRequest instance methods
+proc init*(self: VNRecognizeTextRequest): VNRecognizeTextRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNRecognizeTextRequest, handler: pointer): VNRecognizeTextRequest {.objc: "initWithCompletionHandler:".}
+proc supportedRecognitionLanguagesAndReturnError*(self: VNRecognizeTextRequest, error: ptr NSError = nil): NSArray {.objc: "supportedRecognitionLanguagesAndReturnError:".}
+proc recognitionLanguages*(self: VNRecognizeTextRequest): NSArray {.objc: "recognitionLanguages".}
+proc setRecognitionLanguages*(self: VNRecognizeTextRequest, languages: NSArray) {.objc: "setRecognitionLanguages:".}
+proc customWords*(self: VNRecognizeTextRequest): NSArray {.objc: "customWords".}
+proc setCustomWords*(self: VNRecognizeTextRequest, words: NSArray) {.objc: "setCustomWords:".}
+proc recognitionLevel*(self: VNRecognizeTextRequest): VNRequestTextRecognitionLevel {.objc: "recognitionLevel".}
+proc setRecognitionLevel*(self: VNRecognizeTextRequest, level: VNRequestTextRecognitionLevel) {.objc: "setRecognitionLevel:".}
+proc usesLanguageCorrection*(self: VNRecognizeTextRequest): bool {.objc: "usesLanguageCorrection".}
+proc setUsesLanguageCorrection*(self: VNRecognizeTextRequest, value: bool) {.objc: "setUsesLanguageCorrection:".}
+proc automaticallyDetectsLanguage*(self: VNRecognizeTextRequest): bool {.objc: "automaticallyDetectsLanguage".}
+proc setAutomaticallyDetectsLanguage*(self: VNRecognizeTextRequest, value: bool) {.objc: "setAutomaticallyDetectsLanguage:".}
+proc minimumTextHeight*(self: VNRecognizeTextRequest): cfloat {.objc: "minimumTextHeight".}
+proc setMinimumTextHeight*(self: VNRecognizeTextRequest, value: cfloat) {.objc: "setMinimumTextHeight:".}
+proc results*(self: VNRecognizeTextRequest): NSArray {.objc: "results".}  # NSArray<VNRecognizedTextObservation*>
+
+# Progress handling
+proc progressHandler*(self: VNRecognizeTextRequest): pointer {.objc: "progressHandler".}
+proc setProgressHandler*(self: VNRecognizeTextRequest, handler: pointer) {.objc: "setProgressHandler:".}
+proc indeterminate*(self: VNRecognizeTextRequest): bool {.objc: "indeterminate".}

--- a/darwin/vision/vnrecognizetextrequest.nim
+++ b/darwin/vision/vnrecognizetextrequest.nim
@@ -9,16 +9,16 @@ type
   VNRecognizeTextRequest* = ptr object of VNImageBasedRequest
 
 # VNRecognizeTextRequest class methods
-proc supportedRecognitionLanguagesForTextRecognitionLevelRevisionError*(self: typedesc[VNRecognizeTextRequest], recognitionLevel: VNRequestTextRecognitionLevel, requestRevision: NSUInteger, error: ptr NSError = nil): NSArray {.objc: "supportedRecognitionLanguagesForTextRecognitionLevel:revision:error:".}
+proc supportedRecognitionLanguagesForTextRecognitionLevelRevisionError*(self: typedesc[VNRecognizeTextRequest], recognitionLevel: VNRequestTextRecognitionLevel, requestRevision: NSUInteger, error: ptr NSError = nil): NSArray[NSString] {.objc: "supportedRecognitionLanguagesForTextRecognitionLevel:revision:error:".}
 
 # VNRecognizeTextRequest instance methods
 proc init*(self: VNRecognizeTextRequest): VNRecognizeTextRequest {.objc: "init".}
 proc initWithCompletionHandler*(self: VNRecognizeTextRequest, handler: pointer): VNRecognizeTextRequest {.objc: "initWithCompletionHandler:".}
-proc supportedRecognitionLanguagesAndReturnError*(self: VNRecognizeTextRequest, error: ptr NSError = nil): NSArray {.objc: "supportedRecognitionLanguagesAndReturnError:".}
-proc recognitionLanguages*(self: VNRecognizeTextRequest): NSArray {.objc: "recognitionLanguages".}
-proc setRecognitionLanguages*(self: VNRecognizeTextRequest, languages: NSArray) {.objc: "setRecognitionLanguages:".}
-proc customWords*(self: VNRecognizeTextRequest): NSArray {.objc: "customWords".}
-proc setCustomWords*(self: VNRecognizeTextRequest, words: NSArray) {.objc: "setCustomWords:".}
+proc supportedRecognitionLanguagesAndReturnError*(self: VNRecognizeTextRequest, error: ptr NSError = nil): NSArray[NSString] {.objc: "supportedRecognitionLanguagesAndReturnError:".}
+proc recognitionLanguages*(self: VNRecognizeTextRequest): NSArray[NSString] {.objc: "recognitionLanguages".}
+proc setRecognitionLanguages*(self: VNRecognizeTextRequest, languages: NSArray[NSString]) {.objc: "setRecognitionLanguages:".}
+proc customWords*(self: VNRecognizeTextRequest): NSArray[NSString] {.objc: "customWords".}
+proc setCustomWords*(self: VNRecognizeTextRequest, words: NSArray[NSString]) {.objc: "setCustomWords:".}
 proc recognitionLevel*(self: VNRecognizeTextRequest): VNRequestTextRecognitionLevel {.objc: "recognitionLevel".}
 proc setRecognitionLevel*(self: VNRecognizeTextRequest, level: VNRequestTextRecognitionLevel) {.objc: "setRecognitionLevel:".}
 proc usesLanguageCorrection*(self: VNRecognizeTextRequest): bool {.objc: "usesLanguageCorrection".}
@@ -27,7 +27,7 @@ proc automaticallyDetectsLanguage*(self: VNRecognizeTextRequest): bool {.objc: "
 proc setAutomaticallyDetectsLanguage*(self: VNRecognizeTextRequest, value: bool) {.objc: "setAutomaticallyDetectsLanguage:".}
 proc minimumTextHeight*(self: VNRecognizeTextRequest): cfloat {.objc: "minimumTextHeight".}
 proc setMinimumTextHeight*(self: VNRecognizeTextRequest, value: cfloat) {.objc: "setMinimumTextHeight:".}
-proc results*(self: VNRecognizeTextRequest): NSArray {.objc: "results".}  # NSArray<VNRecognizedTextObservation*>
+proc results*(self: VNRecognizeTextRequest): NSArray[VNRecognizedTextObservation] {.objc: "results".}
 
 # Progress handling
 proc progressHandler*(self: VNRecognizeTextRequest): pointer {.objc: "progressHandler".}

--- a/darwin/vision/vnrequest.nim
+++ b/darwin/vision/vnrequest.nim
@@ -1,0 +1,33 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nserror
+import ../foundation/nsstring
+import ../foundation/nsindexset
+import ../core_graphics/cggeometry
+import vntypes
+
+type
+  VNRequest* = ptr object of NSObject
+  VNImageBasedRequest* = ptr object of VNRequest
+
+# VNRequest methods
+proc init*(self: VNRequest): VNRequest {.objc: "init".}
+proc initWithCompletionHandler*(self: VNRequest, handler: pointer): VNRequest {.objc: "initWithCompletionHandler:".}
+proc preferBackgroundProcessing*(self: VNRequest): bool {.objc: "preferBackgroundProcessing".}
+proc setPreferBackgroundProcessing*(self: VNRequest, value: bool) {.objc: "setPreferBackgroundProcessing:".}
+proc usesCPUOnly*(self: VNRequest): bool {.objc: "usesCPUOnly".}
+proc setUsesCPUOnly*(self: VNRequest, value: bool) {.objc: "setUsesCPUOnly:".}
+proc results*(self: VNRequest): NSArray {.objc: "results".}
+proc completionHandler*(self: VNRequest): pointer {.objc: "completionHandler".}
+proc revision*(self: VNRequest): NSUInteger {.objc: "revision".}
+proc setRevision*(self: VNRequest, value: NSUInteger) {.objc: "setRevision:".}
+proc cancel*(self: VNRequest) {.objc: "cancel".}
+
+# Class methods for VNRequest
+proc supportedRevisions*(self: typedesc[VNRequest]): NSIndexSet {.objc: "supportedRevisions".}
+proc defaultRevision*(self: typedesc[VNRequest]): NSUInteger {.objc: "defaultRevision".}
+proc currentRevision*(self: typedesc[VNRequest]): NSUInteger {.objc: "currentRevision".}
+
+# VNImageBasedRequest methods
+proc regionOfInterest*(self: VNImageBasedRequest): CGRect {.objc: "regionOfInterest".}
+proc setRegionOfInterest*(self: VNImageBasedRequest, value: CGRect) {.objc: "setRegionOfInterest:".}

--- a/darwin/vision/vnrequest.nim
+++ b/darwin/vision/vnrequest.nim
@@ -5,6 +5,7 @@ import ../foundation/nsstring
 import ../foundation/nsindexset
 import ../core_graphics/cggeometry
 import vntypes
+import vnobservation
 
 type
   VNRequest* = ptr object of NSObject
@@ -17,7 +18,7 @@ proc preferBackgroundProcessing*(self: VNRequest): bool {.objc: "preferBackgroun
 proc setPreferBackgroundProcessing*(self: VNRequest, value: bool) {.objc: "setPreferBackgroundProcessing:".}
 proc usesCPUOnly*(self: VNRequest): bool {.objc: "usesCPUOnly".}
 proc setUsesCPUOnly*(self: VNRequest, value: bool) {.objc: "setUsesCPUOnly:".}
-proc results*(self: VNRequest): NSArray {.objc: "results".}
+proc results*(self: VNRequest): NSArray[VNObservation] {.objc: "results".}
 proc completionHandler*(self: VNRequest): pointer {.objc: "completionHandler".}
 proc revision*(self: VNRequest): NSUInteger {.objc: "revision".}
 proc setRevision*(self: VNRequest, value: NSUInteger) {.objc: "setRevision:".}

--- a/darwin/vision/vnrequesthandler.nim
+++ b/darwin/vision/vnrequesthandler.nim
@@ -1,0 +1,47 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import ../foundation/nserror
+import ../foundation/nsstring
+import ../foundation/nsurl
+import ../foundation/nsdata
+import ../foundation/nsdictionary
+import ../core_graphics/cgimage
+import ../core_video/cvbuffer
+import vnrequest
+
+# CIImage is an Objective-C class
+type
+  CIImage* = ptr object of NSObject
+
+  VNImageRequestHandler* = ptr object of NSObject
+  VNSequenceRequestHandler* = ptr object of NSObject
+
+# VNImageRequestHandler init methods - using overloading
+proc initWithCVPixelBuffer*(self: VNImageRequestHandler, pixelBuffer: CVPixelBufferRef, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCVPixelBuffer:options:".}
+proc initWithCVPixelBuffer*(self: VNImageRequestHandler, pixelBuffer: CVPixelBufferRef, orientation: cuint, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCVPixelBuffer:orientation:options:".}
+proc initWithCGImage*(self: VNImageRequestHandler, image: CGImage, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCGImage:options:".}
+proc initWithCGImage*(self: VNImageRequestHandler, image: CGImage, orientation: cuint, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCGImage:orientation:options:".}
+proc initWithCIImage*(self: VNImageRequestHandler, image: CIImage, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCIImage:options:".}
+proc initWithCIImage*(self: VNImageRequestHandler, image: CIImage, orientation: cuint, options: NSDictionary): VNImageRequestHandler {.objc: "initWithCIImage:orientation:options:".}
+proc initWithURL*(self: VNImageRequestHandler, imageURL: NSURL, options: NSDictionary): VNImageRequestHandler {.objc: "initWithURL:options:".}
+proc initWithURL*(self: VNImageRequestHandler, imageURL: NSURL, orientation: cuint, options: NSDictionary): VNImageRequestHandler {.objc: "initWithURL:orientation:options:".}
+proc initWithData*(self: VNImageRequestHandler, imageData: NSData, options: NSDictionary): VNImageRequestHandler {.objc: "initWithData:options:".}
+proc initWithData*(self: VNImageRequestHandler, imageData: NSData, orientation: cuint, options: NSDictionary): VNImageRequestHandler {.objc: "initWithData:orientation:options:".}
+
+# VNImageRequestHandler perform methods
+proc performRequests*(self: VNImageRequestHandler, requests: NSArray, error: ptr NSError = nil): bool {.objc: "performRequests:error:".}
+
+# VNSequenceRequestHandler init
+proc init*(self: VNSequenceRequestHandler): VNSequenceRequestHandler {.objc: "init".}
+
+# VNSequenceRequestHandler perform methods - using overloading based on type
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, pixelBuffer: CVPixelBufferRef, error: ptr NSError = nil): bool {.objc: "performRequests:onCVPixelBuffer:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, pixelBuffer: CVPixelBufferRef, orientation: cuint, error: ptr NSError = nil): bool {.objc: "performRequests:onCVPixelBuffer:orientation:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, image: CGImage, error: ptr NSError = nil): bool {.objc: "performRequests:onCGImage:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, image: CGImage, orientation: cuint, error: ptr NSError = nil): bool {.objc: "performRequests:onCGImage:orientation:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, image: CIImage, error: ptr NSError = nil): bool {.objc: "performRequests:onCIImage:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, image: CIImage, orientation: cuint, error: ptr NSError = nil): bool {.objc: "performRequests:onCIImage:orientation:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, imageURL: NSURL, error: ptr NSError = nil): bool {.objc: "performRequests:onImageURL:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, imageURL: NSURL, orientation: cuint, error: ptr NSError = nil): bool {.objc: "performRequests:onImageURL:orientation:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, imageData: NSData, error: ptr NSError = nil): bool {.objc: "performRequests:onImageData:error:".}
+proc performRequests*(self: VNSequenceRequestHandler, requests: NSArray, imageData: NSData, orientation: cuint, error: ptr NSError = nil): bool {.objc: "performRequests:onImageData:orientation:error:".}

--- a/darwin/vision/vntypes.nim
+++ b/darwin/vision/vntypes.nim
@@ -1,0 +1,102 @@
+import ../objc/runtime
+import ../foundation/nsstring
+
+# Type definitions
+type
+  VNConfidence* = cfloat
+  VNAspectRatio* = cfloat
+  VNDegrees* = cfloat
+
+  VNImageCropAndScaleOption* {.size: sizeof(cuint).} = enum
+    vnImageCropAndScaleOptionCenterCrop = 0
+    vnImageCropAndScaleOptionScaleFit = 1
+    vnImageCropAndScaleOptionScaleFill = 2
+    vnImageCropAndScaleOptionScaleFitRotate90CCW = 0x100
+    vnImageCropAndScaleOptionScaleFillRotate90CCW = 0x101
+
+  VNElementType* {.size: sizeof(cuint).} = enum
+    vnElementTypeUnknown = 0
+    vnElementTypeFloat = 1
+    vnElementTypeDouble = 2
+
+  VNChirality* {.size: sizeof(cint).} = enum
+    vnChiralityUnknown = 0
+    vnChiralityLeft = -1
+    vnChiralityRight = 1
+
+  VNPointsClassification* {.size: sizeof(cint).} = enum
+    vnPointsClassificationDisconnected = 0
+    vnPointsClassificationOpenPath = 1
+    vnPointsClassificationClosedPath = 2
+
+  VNBarcodeCompositeType* {.size: sizeof(cint).} = enum
+    vnBarcodeCompositeTypeNone = 0
+    vnBarcodeCompositeTypeLinked = 1
+    vnBarcodeCompositeTypeGS1TypeA = 2
+    vnBarcodeCompositeTypeGS1TypeB = 3
+    vnBarcodeCompositeTypeGS1TypeC = 4
+
+  VNRequestTextRecognitionLevel* {.size: sizeof(cint).} = enum
+    vnRequestTextRecognitionLevelAccurate = 0
+    vnRequestTextRecognitionLevelFast = 1
+
+  VNBarcodeSymbology* = NSString
+  VNRecognizedPointKey* = NSString
+  VNRecognizedPointGroupKey* = NSString
+  VNComputeStage* = NSString
+  VNImageOption* = NSString
+
+# Barcode symbology constants
+var
+  VNBarcodeSymbologyAztec* {.importc.}: NSString
+  VNBarcodeSymbologyCode39* {.importc.}: NSString
+  VNBarcodeSymbologyCode39Checksum* {.importc.}: NSString
+  VNBarcodeSymbologyCode39FullASCII* {.importc.}: NSString
+  VNBarcodeSymbologyCode39FullASCIIChecksum* {.importc.}: NSString
+  VNBarcodeSymbologyCode93* {.importc.}: NSString
+  VNBarcodeSymbologyCode93i* {.importc.}: NSString
+  VNBarcodeSymbologyCode128* {.importc.}: NSString
+  VNBarcodeSymbologyDataMatrix* {.importc.}: NSString
+  VNBarcodeSymbologyEAN8* {.importc.}: NSString
+  VNBarcodeSymbologyEAN13* {.importc.}: NSString
+  VNBarcodeSymbologyI2of5* {.importc.}: NSString
+  VNBarcodeSymbologyI2of5Checksum* {.importc.}: NSString
+  VNBarcodeSymbologyITF14* {.importc.}: NSString
+  VNBarcodeSymbologyPDF417* {.importc.}: NSString
+  VNBarcodeSymbologyQR* {.importc.}: NSString
+  VNBarcodeSymbologyUPCE* {.importc.}: NSString
+  VNBarcodeSymbologyCodabar* {.importc.}: NSString
+  VNBarcodeSymbologyGS1DataBar* {.importc.}: NSString
+  VNBarcodeSymbologyGS1DataBarExpanded* {.importc.}: NSString
+  VNBarcodeSymbologyGS1DataBarLimited* {.importc.}: NSString
+  VNBarcodeSymbologyMicroPDF417* {.importc.}: NSString
+  VNBarcodeSymbologyMicroQR* {.importc.}: NSString
+  VNBarcodeSymbologyMSIPlessey* {.importc.}: NSString
+
+# Compute stage constants
+var
+  VNComputeStageMain* {.importc.}: NSString
+  VNComputeStagePostProcessing* {.importc.}: NSString
+
+# Image option constants
+var
+  VNImageOptionProperties* {.importc.}: NSString
+  VNImageOptionCameraIntrinsics* {.importc.}: NSString
+  VNImageOptionCIContext* {.importc.}: NSString
+
+# Revision constants
+const
+  VNRequestRevisionUnspecified* = 0.NSUInteger
+
+  VNDetectFaceRectanglesRequestRevision1* = 1.NSUInteger
+  VNDetectFaceRectanglesRequestRevision2* = 2.NSUInteger
+  VNDetectFaceRectanglesRequestRevision3* = 3.NSUInteger
+
+  VNRecognizeTextRequestRevision1* = 1.NSUInteger
+  VNRecognizeTextRequestRevision2* = 2.NSUInteger
+  VNRecognizeTextRequestRevision3* = 3.NSUInteger
+
+  VNDetectBarcodesRequestRevision1* = 1.NSUInteger
+  VNDetectBarcodesRequestRevision2* = 2.NSUInteger
+  VNDetectBarcodesRequestRevision3* = 3.NSUInteger
+  VNDetectBarcodesRequestRevision4* = 4.NSUInteger

--- a/tests/tmain_modules_compile.nim
+++ b/tests/tmain_modules_compile.nim
@@ -7,6 +7,7 @@ import darwin/quartz_core
 import darwin/store_kit
 import darwin/ui_kit
 import darwin/web_kit
+import darwin/vision
 
 export app_kit
 export core_foundation
@@ -17,3 +18,4 @@ export quartz_core
 export store_kit
 export ui_kit
 export web_kit
+export vision

--- a/tests/tvision.nim
+++ b/tests/tvision.nim
@@ -1,0 +1,53 @@
+import darwin/vision
+import darwin/foundation
+import darwin/core_graphics/cggeometry
+import darwin/objc/runtime
+
+# Test VNDetectFaceRectanglesRequest
+var faceRequest = VNDetectFaceRectanglesRequest.alloc().init()
+faceRequest.setPreferBackgroundProcessing(true)
+doAssert faceRequest.preferBackgroundProcessing()
+faceRequest.setRevision(VNDetectFaceRectanglesRequestRevision2)
+doAssert faceRequest.revision() == VNDetectFaceRectanglesRequestRevision2
+
+# Test VNImageBasedRequest region of interest
+var imageRequest = cast[VNImageBasedRequest](faceRequest)
+var rect: CGRect
+rect.origin.x = 0.0
+rect.origin.y = 0.0
+rect.size.width = 1.0
+rect.size.height = 1.0
+imageRequest.setRegionOfInterest(rect)
+var roi = imageRequest.regionOfInterest()
+doAssert roi.size.width == 1.0
+
+# Test VNRecognizeTextRequest properties
+var textRequest = VNRecognizeTextRequest.alloc().init()
+textRequest.setRecognitionLevel(vnRequestTextRecognitionLevelAccurate)
+doAssert textRequest.recognitionLevel() == vnRequestTextRecognitionLevelAccurate
+textRequest.setUsesLanguageCorrection(true)
+doAssert textRequest.usesLanguageCorrection()
+textRequest.setMinimumTextHeight(0.5)
+doAssert textRequest.minimumTextHeight() == 0.5
+
+# Test VNBarcodeSymbology constants
+var barcodeRequest = VNDetectBarcodesRequest.alloc().init()
+doAssert VNBarcodeSymbologyQR != nil
+
+# Test VNGeometry
+var point = VNPoint.alloc().init(10.0, 20.0)
+doAssert point.x() == 10.0
+doAssert point.y() == 20.0
+
+var vector = VNVector.alloc().initWithComponents(3.0, 4.0)
+doAssert vector.length() == 5.0
+
+var center = VNPoint.alloc().init(0.0, 0.0)
+var circle = VNCircle.alloc().initWithCenterRadius(center, 5.0)
+doAssert circle.radius() == 5.0
+
+var circle2 = VNCircle.alloc().initWithCenterDiameter(center, 10.0)
+doAssert circle2.diameter() == 10.0
+
+var testPoint = VNPoint.alloc().init(1.0, 1.0)
+doAssert circle.containsPoint(testPoint)


### PR DESCRIPTION
- Add comprehensive Vision framework bindings for macOS/iOS
- Include core types (VNRequest, VNImageRequestHandler, VNSequenceRequestHandler)
- Add observation types (VNObservation, VNFaceObservation, VNBarcodeObservation, etc.)
- Add geometry types (VNPoint, VNVector, VNCircle, VNContour)
- Add request types (face detection, text recognition, barcode detection, rectangle detection, saliency)
- Add supporting Foundation types (NSIndexSet, NSUUID)
- Add CoreVideo buffer type definitions (CVBufferRef, CVPixelBufferRef)
- Use Nim overloading for cleaner API where appropriate
- Add tests for Vision framework