### PR TITLE
fix: add missing WebKit framework linkage

### DIFF
--- a/darwin/web_kit.nim
+++ b/darwin/web_kit.nim
@@ -1,3 +1,5 @@
+{.passL: "-framework WebKit".}
+
 import web_kit / [wkwebview, wkwebviewconfiguration, wknavigation,
     wkusercontentcontroller, wkuserscript, wkpreferences, wknavigationdelegate,
     wknavigationresponse, wkopenpanelparameters, wkframeinfo, wkscriptmessage]


### PR DESCRIPTION
Add {.passL: "-framework WebKit".} to the entry module so consumers link against the WebKit framework automatically.