### PR TITLE
feat: add AVFoundation video capture bindings

### DIFF
--- a/darwin/av_foundation.nim
+++ b/darwin/av_foundation.nim
@@ -1,4 +1,4 @@
-import av_foundation / [avaudioplayer, avaudioplayerdelegate, avaudioformat, avaudioengine, avaudioplayernode, avaudiopcmbuffer, avaudionode, avaudiomixernode]
-export avaudioplayer, avaudioplayerdelegate, avaudioformat, avaudioengine, avaudioplayernode, avaudiopcmbuffer, avaudionode, avaudiomixernode
+import av_foundation / [avaudioplayer, avaudioplayerdelegate, avaudioformat, avaudioengine, avaudioplayernode, avaudiopcmbuffer, avaudionode, avaudiomixernode, avcapturesession, avcapturedevice, avcaptureinput, avcaptureoutput, avcapturevideodataoutput, avcaptureconnection]
+export avaudioplayer, avaudioplayerdelegate, avaudioformat, avaudioengine, avaudioplayernode, avaudiopcmbuffer, avaudionode, avaudiomixernode, avcapturesession, avcapturedevice, avcaptureinput, avcaptureoutput, avcapturevideodataoutput, avcaptureconnection
 
 {.passL: "-framework AVFoundation".}

--- a/darwin/av_foundation/avcaptureconnection.nim
+++ b/darwin/av_foundation/avcaptureconnection.nim
@@ -1,0 +1,13 @@
+import ../objc/runtime
+
+type
+  AVCaptureConnection* = ptr object of NSObject
+  AVCaptureVideoOrientation* {.size: sizeof(cint).} = enum
+    Portrait = 1
+    PortraitUpsideDown = 2
+    LandscapeRight = 3
+    LandscapeLeft = 4
+
+# AVCaptureConnection methods
+proc setVideoOrientation*(c: AVCaptureConnection, orientation: AVCaptureVideoOrientation) {.objc: "setVideoOrientation:".}
+proc isVideoOrientationSupported*(c: AVCaptureConnection): BOOL {.objc.}

--- a/darwin/av_foundation/avcapturedevice.nim
+++ b/darwin/av_foundation/avcapturedevice.nim
@@ -1,0 +1,21 @@
+import ../objc/runtime
+import ../foundation/[nsstring, nsarray, nserror]
+
+type
+  AVCaptureDevice* = ptr object of NSObject
+  AVCaptureDevicePosition* {.size: sizeof(cint).} = enum
+    Unspecified = 0
+    Back = 1
+    Front = 2
+
+  AVMediaType* = NSString
+
+# Device discovery
+proc defaultDeviceWithMediaType*(self: typedesc[AVCaptureDevice], mediaType: AVMediaType): AVCaptureDevice {.objc: "defaultDeviceWithMediaType:".}
+proc devices*(self: typedesc[AVCaptureDevice]): NSArray[AVCaptureDevice] {.objc.}
+proc hasMediaType*(d: AVCaptureDevice, mediaType: AVMediaType): BOOL {.objc: "hasMediaType:".}
+proc position*(d: AVCaptureDevice): AVCaptureDevicePosition {.objc.}
+proc localizedName*(d: AVCaptureDevice): NSString {.objc.}
+
+# Media type constants
+var AVMediaTypeVideo* {.importc.}: AVMediaType

--- a/darwin/av_foundation/avcaptureinput.nim
+++ b/darwin/av_foundation/avcaptureinput.nim
@@ -1,0 +1,10 @@
+import ../objc/runtime
+import ../foundation/nserror
+import avcapturedevice
+
+type
+  AVCaptureDeviceInput* = ptr object of NSObject
+
+# AVCaptureDeviceInput methods
+proc alloc*(t: typedesc[AVCaptureDeviceInput]): AVCaptureDeviceInput {.objc: "alloc".}
+proc initWithDevice*(i: AVCaptureDeviceInput, device: AVCaptureDevice, error: ptr ID): AVCaptureDeviceInput {.objc: "initWithDevice:error:".}

--- a/darwin/av_foundation/avcaptureoutput.nim
+++ b/darwin/av_foundation/avcaptureoutput.nim
@@ -1,0 +1,4 @@
+import ../objc/runtime
+
+type
+  AVCaptureOutput* = ptr object of NSObject

--- a/darwin/av_foundation/avcapturesession.nim
+++ b/darwin/av_foundation/avcapturesession.nim
@@ -1,0 +1,20 @@
+import ../objc/runtime
+import ../foundation/nsarray
+import avcaptureinput
+import avcapturevideodataoutput
+
+type
+  AVCaptureSession* = ptr object of NSObject
+
+# AVCaptureSession methods
+proc alloc*(t: typedesc[AVCaptureSession]): AVCaptureSession {.objc: "alloc".}
+proc init*(s: AVCaptureSession): AVCaptureSession {.objc: "init".}
+proc startRunning*(s: AVCaptureSession) {.objc.}
+proc stopRunning*(s: AVCaptureSession) {.objc.}
+proc isRunning*(s: AVCaptureSession): BOOL {.objc.}
+proc canAddInput*(s: AVCaptureSession, input: AVCaptureDeviceInput): BOOL {.objc: "canAddInput:".}
+proc addInput*(s: AVCaptureSession, input: AVCaptureDeviceInput) {.objc: "addInput:".}
+proc canAddOutput*(s: AVCaptureSession, output: AVCaptureVideoDataOutput): BOOL {.objc: "canAddOutput:".}
+proc addOutput*(s: AVCaptureSession, output: AVCaptureVideoDataOutput) {.objc: "addOutput:".}
+proc beginConfiguration*(s: AVCaptureSession) {.objc.}
+proc commitConfiguration*(s: AVCaptureSession) {.objc.}

--- a/darwin/av_foundation/avcapturevideodataoutput.nim
+++ b/darwin/av_foundation/avcapturevideodataoutput.nim
@@ -1,0 +1,19 @@
+import ../objc/runtime
+import ../foundation/[nsarray, nsdictionary, nsnumber, nsstring]
+import avcaptureoutput
+import avcaptureconnection
+
+type
+  AVCaptureVideoDataOutput* = ptr object of AVCaptureOutput
+  DispatchQueue = pointer
+
+# AVCaptureVideoDataOutput methods
+proc alloc*(t: typedesc[AVCaptureVideoDataOutput]): AVCaptureVideoDataOutput {.objc: "alloc".}
+proc init*(o: AVCaptureVideoDataOutput): AVCaptureVideoDataOutput {.objc: "init".}
+proc setAlwaysDiscardsLateVideoFrames*(o: AVCaptureVideoDataOutput, enabled: BOOL) {.objc: "setAlwaysDiscardsLateVideoFrames:".}
+proc availableVideoPixelFormatTypes*(o: AVCaptureVideoDataOutput): NSArray[NSNumber] {.objc.}
+proc setVideoSettings*(o: AVCaptureVideoDataOutput, settings: NSDictionary) {.objc: "setVideoSettings:".}
+proc setSampleBufferDelegate*(o: AVCaptureVideoDataOutput, delegate: NSObject, queue: DispatchQueue) {.objc: "setSampleBufferDelegate:queue:".}
+
+# Connection
+proc connectionWithMediaType*(o: AVCaptureVideoDataOutput, mediaType: NSString): AVCaptureConnection {.objc.}


### PR DESCRIPTION
Add AVCaptureSession and related classes for camera/video input capture.

- av_foundation.nim: export new capture modules
- avcapturesession.nim: session lifecycle, input/output management
- avcapturedevice.nim: device discovery, position, media types
- avcaptureinput.nim: AVCaptureDeviceInput
- avcaptureoutput.nim: AVCaptureOutput base type
- avcapturevideodataoutput.nim: video data output with delegate support
- avcaptureconnection.nim: connection orientation control