### PR TITLE
feat: add CoreImage bindings

### DIFF
--- a/darwin/core_image.nim
+++ b/darwin/core_image.nim
@@ -1,0 +1,4 @@
+import core_image/[ciimage, cicontext, cidetector, cifeature]
+export ciimage, cicontext, cidetector, cifeature
+
+{.passL: "-framework CoreImage".}

--- a/darwin/core_image/cicontext.nim
+++ b/darwin/core_image/cicontext.nim
@@ -1,0 +1,14 @@
+import ../objc/runtime
+import ../core_graphics/[cgimage, cggeometry]
+import ../foundation/nsdictionary
+import ciimage
+
+type
+  CIContext* = ptr object of NSObject
+
+# CIContext creation
+proc context*(t: typedesc[CIContext]): CIContext {.objc.}
+proc contextWithOptions*(t: typedesc[CIContext], options: NSDictionary): CIContext {.objc: "contextWithOptions:".}
+
+# Rendering
+proc createCGImage*(c: CIContext, image: CIImage, fromRect: CGRect): CGImage {.objc: "createCGImage:fromRect:".}

--- a/darwin/core_image/cidetector.nim
+++ b/darwin/core_image/cidetector.nim
@@ -1,0 +1,33 @@
+import ../objc/runtime
+import ../foundation/[nsstring, nsarray, nsdictionary]
+import ciimage
+import cicontext
+
+type
+  CIDetector* = ptr object of NSObject
+  CIDetectorType* = NSString
+
+# CIDetector creation
+proc detectorOfType*(t: typedesc[CIDetector], `type`: CIDetectorType, context: CIContext, options: NSDictionary): CIDetector {.objc: "detectorOfType:context:options:".}
+
+# Feature detection
+proc featuresInImage*(d: CIDetector, image: CIImage): NSArray[ptr NSObject] {.objc: "featuresInImage:".}
+proc featuresInImage*(d: CIDetector, image: CIImage, options: NSDictionary): NSArray[ptr NSObject] {.objc: "featuresInImage:options:".}
+
+# CIDetector types
+var CIDetectorTypeFace* {.importc.}: CIDetectorType
+var CIDetectorTypeRectangle* {.importc.}: CIDetectorType
+var CIDetectorTypeQRCode* {.importc.}: CIDetectorType
+
+# CIDetector options
+var CIDetectorAccuracy* {.importc.}: NSString
+var CIDetectorAccuracyLow* {.importc.}: NSString
+var CIDetectorAccuracyHigh* {.importc.}: NSString
+var CIDetectorTracking* {.importc.}: NSString
+var CIDetectorMinFeatureSize* {.importc.}: NSString
+var CIDetectorMaxFeatureCount* {.importc.}: NSString
+
+# Image options
+var CIDetectorImageOrientation* {.importc.}: NSString
+var CIDetectorEyeBlink* {.importc.}: NSString
+var CIDetectorSmile* {.importc.}: NSString

--- a/darwin/core_image/cifeature.nim
+++ b/darwin/core_image/cifeature.nim
@@ -1,0 +1,32 @@
+import ../objc/runtime
+import ../core_graphics/cggeometry
+import ../foundation/nsstring
+
+type
+  CIFeature* = ptr object of NSObject
+  CIFaceFeature* = ptr object of CIFeature
+  CIRectangleFeature* = ptr object of CIFeature
+  CIQRCodeFeature* = ptr object of CIFeature
+  CIFeatureType* = NSString
+
+# CIFeature properties
+proc `type`*(f: CIFeature): NSString {.objc.}
+proc bounds*(f: CIFeature): CGRect {.objc.}
+
+# CIFaceFeature properties
+proc hasFaceAngle*(f: CIFaceFeature): BOOL {.objc.}
+proc faceAngle*(f: CIFaceFeature): float32 {.objc.}
+proc hasLeftEyePosition*(f: CIFaceFeature): BOOL {.objc.}
+proc leftEyePosition*(f: CIFaceFeature): CGPoint {.objc.}
+proc hasRightEyePosition*(f: CIFaceFeature): BOOL {.objc.}
+proc rightEyePosition*(f: CIFaceFeature): CGPoint {.objc.}
+proc hasMouthPosition*(f: CIFaceFeature): BOOL {.objc.}
+proc mouthPosition*(f: CIFaceFeature): CGPoint {.objc.}
+proc hasSmile*(f: CIFaceFeature): BOOL {.objc.}
+proc leftEyeClosed*(f: CIFaceFeature): BOOL {.objc.}
+proc rightEyeClosed*(f: CIFaceFeature): BOOL {.objc.}
+
+# Feature types
+var CIFeatureTypeFace* {.importc.}: CIFeatureType
+var CIFeatureTypeRectangle* {.importc.}: CIFeatureType
+var CIFeatureTypeQRCode* {.importc.}: CIFeatureType

--- a/darwin/core_image/ciimage.nim
+++ b/darwin/core_image/ciimage.nim
@@ -1,0 +1,25 @@
+import ../objc/runtime
+import ../core_graphics/[cgimage, cggeometry]
+import ../foundation/[nsstring, nsarray, nsdictionary]
+
+type
+  CIImage* = ptr object of NSObject
+  CIFormat* = cint
+
+# CIImage creation
+proc imageWithCGImage*(t: typedesc[CIImage], image: CGImage): CIImage {.objc: "imageWithCGImage:".}
+proc imageWithCGImage*(t: typedesc[CIImage], image: CGImage, options: NSDictionary): CIImage {.objc: "imageWithCGImage:options:".}
+
+# CVPixelBuffer support
+type CVPixelBuffer = pointer
+proc imageWithCVPixelBuffer*(t: typedesc[CIImage], pixelBuffer: CVPixelBuffer): CIImage {.objc: "imageWithCVPixelBuffer:".}
+proc imageWithCVPixelBuffer*(t: typedesc[CIImage], pixelBuffer: CVPixelBuffer, options: NSDictionary): CIImage {.objc: "imageWithCVPixelBuffer:options:".}
+
+# CIImage properties
+proc extent*(i: CIImage): CGRect {.objc.}
+proc properties*(i: CIImage): NSDictionary {.objc.}
+
+# CIFormat constants
+var kCIFormatARGB8* {.importc.}: CIFormat
+var kCIFormatBGRA8* {.importc.}: CIFormat
+var kCIFormatRGBA8* {.importc.}: CIFormat


### PR DESCRIPTION
Add CoreImage framework for image processing and feature detection.

- core_image.nim: new framework entry module
- ciimage.nim: CIImage creation from CGImage and CVPixelBuffer
- cicontext.nim: CIContext for rendering to CGImage
- cidetector.nim: CIDetector for face/rectangle/QR code detection
- cifeature.nim: CIFeature, CIFaceFeature, and related types