### PR TITLE
feat: add CGEvent bindings for input event queries

### DIFF
--- a/darwin/core_graphics.nim
+++ b/darwin/core_graphics.nim
@@ -1,7 +1,7 @@
 {.passL: "-framework CoreGraphics".}
 
-import core_graphics / [cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage, cgdataconsumer]
+import core_graphics / [cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage, cgdataconsumer, cgevent]
 import core_graphics / [cgpdfobject, cgpdfarray, cgpdfdictionary, cgpdfstream, cgpdfstring, cgpdfdocument, cgpdfpage, cgpdfcontext]
 
-export cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage, cgdataconsumer
+export cggeometry, cgfont, cgcolor_space, cgcontext, cgbitmap_context, cgaffine_transform, cgpath, cgimage, cgdataconsumer, cgevent
 export cgpdfobject, cgpdfarray, cgpdfdictionary, cgpdfstream, cgpdfstring, cgpdfdocument, cgpdfpage, cgpdfcontext

--- a/darwin/core_graphics/cgevent.nim
+++ b/darwin/core_graphics/cgevent.nim
@@ -1,0 +1,50 @@
+import ../objc/runtime
+
+type
+  CGEventMask* = uint64
+  CFTimeInterval* = float64
+  CGEventSource* = pointer
+  CGEventSourceStateID* {.size: sizeof(cint).} = enum
+    EventSourceStatePrivate = -1
+    EventSourceStateCombinedSessionState = 0
+    EventSourceStateHIDSystemState = 1
+  CGEventType* {.size: sizeof(cuint).} = enum
+    EventNull = 0
+    LeftMouseDown = 1
+    LeftMouseUp = 2
+    RightMouseDown = 3
+    RightMouseUp = 4
+    MouseMoved = 5
+    LeftMouseDragged = 6
+    RightMouseDragged = 7
+    KeyDown = 10
+    KeyUp = 11
+    FlagsChanged = 12
+    ScrollWheel = 22
+    TabletPointer = 23
+    TabletProximity = 24
+    OtherMouseDown = 25
+    OtherMouseUp = 26
+    OtherMouseDragged = 27
+
+# Get the elapsed seconds since the last input event
+proc CGEventSourceSecondsSinceLastEventType*(
+  stateID: CGEventSourceStateID,
+  eventType: CGEventType
+): CFTimeInterval {.cdecl, importc.}
+
+# Get the event type mask for a given event type
+proc CGEventMaskBit*(eventType: CGEventType): CGEventMask {.inline.} =
+  result = 1.CGEventMask shl eventType.cuint
+
+# Get the elapsed seconds since any input event
+proc CGEventSourceSecondsSinceLastEvent*(
+  stateID: CGEventSourceStateID
+): CFTimeInterval {.cdecl, importc: "CGEventSourceSecondsSinceLastEventType".}
+
+# Convenience proc to get idle time (seconds since any event)
+proc getIdleTime*(): float64 =
+  result = CGEventSourceSecondsSinceLastEventType(
+    EventSourceStateCombinedSessionState,
+    EventNull
+  )


### PR DESCRIPTION
Add CoreGraphics event source APIs for querying idle time and input events.

- core_graphics.nim: export cgevent module
- cgevent.nim: CGEventSourceSecondsSinceLastEventType, CGEventMaskBit, and convenience getIdleTime() proc