### PR TITLE
feat: add CoreMedia and CoreVideo bindings

### DIFF
--- a/darwin/core_media.nim
+++ b/darwin/core_media.nim
@@ -1,0 +1,4 @@
+{.passL: "-framework CoreMedia".}
+
+import core_media/cmsample
+export cmsample

--- a/darwin/core_media/cmsample.nim
+++ b/darwin/core_media/cmsample.nim
@@ -1,0 +1,78 @@
+# CoreMedia CMSampleBuffer bindings
+# https://developer.apple.com/documentation/coremedia/cmsamplebuffer
+
+import ../core_foundation/cfbase
+import ../core_video/cvbuffer
+
+# Types
+type
+  CMSampleBufferRef* = ptr object of CFObject  # CFType
+  CMItemCount* = int64
+  CMTimeValue* = int64
+  CMTimeScale* = int32
+  CMTimeFlags* = uint32
+  CMTimeEpoch* = int64
+  
+  CMTime* = object
+    value*: CMTimeValue
+    timescale*: CMTimeScale
+    flags*: CMTimeFlags
+    epoch*: CMTimeEpoch
+
+  CMTimeRange* = object
+    start*: CMTime
+    duration*: CMTime
+
+# CMSampleBuffer errors
+const
+  kCMSampleBufferError_AllocationFailed* = -12730
+  kCMSampleBufferError_RequiredParameterMissing* = -12731
+  kCMSampleBufferError_AlreadyHasDataBuffer* = -12732
+  kCMSampleBufferError_BufferNotReady* = -12733
+  kCMSampleBufferError_SampleIndexOutOfRange* = -12734
+  kCMSampleBufferError_BufferHasNoSampleSizes* = -12735
+  kCMSampleBufferError_BufferHasNoSampleTimingInfo* = -12736
+  kCMSampleBufferError_ArrayTooSmall* = -12737
+  kCMSampleBufferError_CannotSubdivide* = -12738
+  kCMSampleBufferError_SampleTimingInfoInvalid* = -12739
+  kCMSampleBufferError_InvalidMediaTypeForOperation* = -12740
+  kCMSampleBufferError_InvalidSampleData* = -12741
+  kCMSampleBufferError_InvalidMediaFormat* = -12742
+  kCMSampleBufferError_Invalidated* = -12743
+  kCMSampleBufferError_DataFailed* = -16750
+  kCMSampleBufferError_DataCanceled* = -16751
+
+# Core functions
+proc CMSampleBufferGetImageBuffer*(sbuf: CMSampleBufferRef): CVImageBufferRef {.cdecl, importc.}
+  ## Returns a CMSampleBuffer's CVImageBuffer of media data.
+  ## The caller does not own the returned dataBuffer.
+
+proc CMSampleBufferGetNumSamples*(sbuf: CMSampleBufferRef): CMItemCount {.cdecl, importc.}
+  ## Returns the number of media samples in a CMSampleBuffer.
+
+proc CMSampleBufferGetDuration*(sbuf: CMSampleBufferRef): CMTime {.cdecl, importc.}
+  ## Returns the total duration of a CMSampleBuffer.
+
+proc CMSampleBufferGetPresentationTimeStamp*(sbuf: CMSampleBufferRef): CMTime {.cdecl, importc.}
+  ## Returns the presentation timestamp of the first sample.
+
+proc CMSampleBufferGetDecodeTimeStamp*(sbuf: CMSampleBufferRef): CMTime {.cdecl, importc.}
+  ## Returns the decode timestamp of the first sample.
+
+proc CMSampleBufferGetSampleSize*(sbuf: CMSampleBufferRef; sampleIndex: CMItemCount): uint {.cdecl, importc.}
+  ## Returns the size of a specified sample.
+
+proc CMSampleBufferGetTotalSampleSize*(sbuf: CMSampleBufferRef): uint {.cdecl, importc.}
+  ## Returns the total size in bytes of all samples.
+
+proc CMSampleBufferDataIsReady*(sbuf: CMSampleBufferRef): bool {.cdecl, importc.}
+  ## Returns whether a CMSampleBuffer's data is ready.
+
+proc CMSampleBufferMakeDataReady*(sbuf: CMSampleBufferRef): int32 {.cdecl, importc.}
+  ## Makes a CMSampleBuffer's data ready.
+
+proc CMSampleBufferInvalidate*(sbuf: CMSampleBufferRef): int32 {.cdecl, importc.}
+  ## Invalidates a CMSampleBuffer.
+
+proc CMSampleBufferIsValid*(sbuf: CMSampleBufferRef): bool {.cdecl, importc.}
+  ## Returns whether a CMSampleBuffer is valid.

--- a/darwin/core_video.nim
+++ b/darwin/core_video.nim
@@ -1,0 +1,4 @@
+{.passL: "-framework CoreVideo".}
+
+import core_video/[cvbuffer, cvpixelbuffer]
+export cvbuffer, cvpixelbuffer

--- a/darwin/core_video/cvpixelbuffer.nim
+++ b/darwin/core_video/cvpixelbuffer.nim
@@ -1,0 +1,94 @@
+# CoreVideo CVPixelBuffer bindings
+# https://developer.apple.com/documentation/corevideo/cvpixelbuffer
+
+import ../core_foundation/cfbase
+import cvbuffer
+
+# Types
+type
+  CVPixelBufferRef* = CVImageBufferRef  # Alias
+  
+  CVPixelBufferLockFlags* {.size: sizeof(uint64).} = enum
+    kCVPixelBufferLock_ReadOnly = 1
+
+# Pixel buffer attribute keys
+var
+  kCVPixelBufferPixelFormatTypeKey* {.importc.}: CFString
+  kCVPixelBufferMemoryAllocatorKey* {.importc.}: CFString
+  kCVPixelBufferWidthKey* {.importc.}: CFString
+  kCVPixelBufferHeightKey* {.importc.}: CFString
+  kCVPixelBufferExtendedPixelsLeftKey* {.importc.}: CFString
+  kCVPixelBufferExtendedPixelsTopKey* {.importc.}: CFString
+  kCVPixelBufferExtendedPixelsRightKey* {.importc.}: CFString
+  kCVPixelBufferExtendedPixelsBottomKey* {.importc.}: CFString
+  kCVPixelBufferBytesPerRowAlignmentKey* {.importc.}: CFString
+  kCVPixelBufferCGBitmapContextCompatibilityKey* {.importc.}: CFString
+  kCVPixelBufferCGImageCompatibilityKey* {.importc.}: CFString
+  kCVPixelBufferPlaneAlignmentKey* {.importc.}: CFString
+  kCVPixelBufferIOSurfacePropertiesKey* {.importc.}: CFString
+  kCVPixelBufferMetalCompatibilityKey* {.importc.}: CFString
+
+# Common pixel format types
+const
+  kCVPixelFormatType_32BGRA* = 0x42475241'u32
+  kCVPixelFormatType_32ARGB* = 0x52474241'u32
+  kCVPixelFormatType_24RGB* = 0x00000018'u32
+  kCVPixelFormatType_24BGR* = 0x32344247'u32
+  kCVPixelFormatType_16BE555* = 0x42453535'u32
+  kCVPixelFormatType_16BE565* = 0x42353635'u32
+  kCVPixelFormatType_32RGBA* = 0x41424752'u32
+  kCVPixelFormatType_64ARGB* = 0x62363461'u32
+  kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange* = 0x34323076'u32
+  kCVPixelFormatType_420YpCbCr8BiPlanarFullRange* = 0x34323066'u32
+  kCVPixelFormatType_422YpCbCr8* = 0x32767579'u32
+  kCVPixelFormatType_422YpCbCr8_yuvs* = 0x79757673'u32
+
+# CVPixelBuffer functions
+proc CVPixelBufferGetWidth*(pixelBuffer: CVPixelBufferRef): uint {.cdecl, importc.}
+  ## Returns the width of the pixel buffer.
+
+proc CVPixelBufferGetHeight*(pixelBuffer: CVPixelBufferRef): uint {.cdecl, importc.}
+  ## Returns the height of the pixel buffer.
+
+proc CVPixelBufferGetPixelFormatType*(pixelBuffer: CVPixelBufferRef): uint32 {.cdecl, importc.}
+  ## Returns the pixel format type.
+
+proc CVPixelBufferLockBaseAddress*(pixelBuffer: CVPixelBufferRef; lockFlags: CVPixelBufferLockFlags): int32 {.cdecl, importc.}
+  ## Locks the base address of the pixel buffer.
+
+proc CVPixelBufferUnlockBaseAddress*(pixelBuffer: CVPixelBufferRef; unlockFlags: CVPixelBufferLockFlags): int32 {.cdecl, importc.}
+  ## Unlocks the base address of the pixel buffer.
+
+proc CVPixelBufferGetBaseAddress*(pixelBuffer: CVPixelBufferRef): pointer {.cdecl, importc.}
+  ## Returns the base address of the pixel buffer.
+
+proc CVPixelBufferGetBytesPerRow*(pixelBuffer: CVPixelBufferRef): uint {.cdecl, importc.}
+  ## Returns the bytes per row.
+
+proc CVPixelBufferGetDataSize*(pixelBuffer: CVPixelBufferRef): uint {.cdecl, importc.}
+  ## Returns the data size.
+
+proc CVPixelBufferIsPlanar*(pixelBuffer: CVPixelBufferRef): bool {.cdecl, importc.}
+  ## Returns whether the pixel buffer is planar.
+
+proc CVPixelBufferGetPlaneCount*(pixelBuffer: CVPixelBufferRef): uint {.cdecl, importc.}
+  ## Returns the plane count for planar buffers.
+
+proc CVPixelBufferGetWidthOfPlane*(pixelBuffer: CVPixelBufferRef; planeIndex: uint): uint {.cdecl, importc.}
+  ## Returns the width of a plane.
+
+proc CVPixelBufferGetHeightOfPlane*(pixelBuffer: CVPixelBufferRef; planeIndex: uint): uint {.cdecl, importc.}
+  ## Returns the height of a plane.
+
+proc CVPixelBufferGetBaseAddressOfPlane*(pixelBuffer: CVPixelBufferRef; planeIndex: uint): pointer {.cdecl, importc.}
+  ## Returns the base address of a plane.
+
+proc CVPixelBufferGetBytesPerRowOfPlane*(pixelBuffer: CVPixelBufferRef; planeIndex: uint): uint {.cdecl, importc.}
+  ## Returns the bytes per row of a plane.
+
+# Creation functions
+proc CVPixelBufferCreate*(allocator: CFAllocator; width: uint; height: uint; pixelFormatType: uint32; pixelBufferAttributes: CFObject; pixelBufferOut: ptr CVPixelBufferRef): int32 {.cdecl, importc.}
+  ## Creates a pixel buffer.
+
+proc CVPixelBufferCreateWithBytes*(allocator: CFAllocator; width: uint; height: uint; pixelFormatType: uint32; baseAddress: pointer; bytesPerRow: uint; releaseCallback: pointer; releaseRefCon: pointer; pixelBufferAttributes: CFObject; pixelBufferOut: ptr CVPixelBufferRef): int32 {.cdecl, importc.}
+  ## Creates a pixel buffer with existing bytes.


### PR DESCRIPTION
Add CMSampleBuffer and CVPixelBuffer bindings for media pipeline support.

- core_media.nim: new framework entry module
- cmsample.nim: CMSampleBufferRef, CMTime, CMTimeRange, and related functions
- core_video.nim: updated entry module to export cvpixelbuffer
- cvpixelbuffer.nim: CVPixelBufferRef creation, locking, and plane access